### PR TITLE
Start 2.16.0 development cycle

### DIFF
--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.15.0"
+__version__ = "2.16.0.dev0"


### PR DESCRIPTION
main now carries a .dev0 version between releases per the new feature/fix-branch convention (AGENTS.md). Confirmed python -m build
+ twine check accept the .devN suffix as a valid version.