### PR TITLE
Release 2.17.0

### DIFF
--- a/docs/source/release-notes/2.17.0.md
+++ b/docs/source/release-notes/2.17.0.md
@@ -1,0 +1,4 @@
+(v2.17.0)=
+
+2.17.0 2026-07-27
+Version 2.17.0 adds classifier evaluation and attribution tools for CNN workflows, including permutation importance, Captum and SHAP analyses, attribution aggregation, and plotting support. It completes the partitioned latent and project-analysis pipeline with explicit source selection, transactional immutable generations, memory-aware resource planning, stable molecule identities and indexes, scoped cross-experiment latent access, provenance-checked project embeddings, reproducible model artifacts, append-only growth, and relocation coverage. The default `smftools experiment full` workflow now runs latent analysis after HMM, with an explicit configuration opt-out, versioned completion summaries, documented lifecycle and migration boundaries, and the latent runtime dependencies included in the default installation.

--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -2,6 +2,11 @@
 
 # Release notes
 
+### Version 2.17.0
+
+```{include} /release-notes/2.17.0.md
+```
+
 ### Version 2.16.0
 
 ```{include} /release-notes/2.16.0.md

--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.17.0.dev0"
+__version__ = "2.17.0"


### PR DESCRIPTION
## Summary

- set the package version to the stable `2.17.0`
- add and index the 2.17.0 release notes covering classifier attribution and the completed project/partitioned-latent pipeline
- prepare the release tree for tagging after merge

## User impact

This release makes the classifier evaluation and attribution tools available alongside the completed partitioned latent/project workflow. `smftools experiment full` now includes latent analysis by default, with an explicit opt-out.

## Validation

- `pytest -m unit -q`: 1,092 passed, 9 skipped
- `pytest -m integration -q`: 6 passed, 2 skipped
- `pytest -m smoke -q`: 92 passed, 1 skipped
- `ruff check .`
- `ruff format --check .`
- `sphinx-build -W -b html docs/source docs/_build/html`
- built wheel and sdist under `dist/2.17.0/`
- `twine check dist/2.17.0/*`
- verified wheel metadata reports `Version: 2.17.0`

After merge, the merge commit should be tagged `v2.17.0`. The `2.18.0.dev0` bump will be handled in a separate follow-up PR.