### PR TITLE
Start 2.18.0 development cycle

### DIFF
--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.17.0"
+__version__ = "2.18.0.dev0"


### PR DESCRIPTION
## Summary

- advance the development version from stable `2.17.0` to `2.18.0.dev0`
- keep the development branch version distinguishable from the tagged 2.17.0 release

## User impact

Development builds from `main` will identify themselves as `2.18.0.dev0`. The stable `v2.17.0` release and its artifacts remain unchanged.

## Validation

- `smftools --version`: `2.18.0.dev0`
- installed metadata and source version: `2.18.0.dev0`
- `pytest -m smoke -q`: 92 passed, 1 skipped
- `ruff check .`
- `ruff format --check .`