### PR TITLE
Add ML-700 scale-qualification benchmark harness

### DIFF
--- a/src/smftools/machine_learning/benchmarks/__init__.py
+++ b/src/smftools/machine_learning/benchmarks/__init__.py
@@ -1,0 +1,37 @@
+"""Performance and scalability qualification for the ML data plane (ML-700).
+
+The memory limits enforced by :mod:`smftools.machine_learning.data.partition_dataset`
+are analytic: ``_bytes_per_row`` applies a fixed ``2x`` transient allowance and
+``estimate_materialization_bytes`` a further ``3x``. Those constants are the only
+thing standing between an approved read and an out-of-memory kill, and nothing
+compares them to a measured peak. This package measures that gap.
+
+The headline quantity is the *headroom ratio* ``peak_rss_delta / estimated_bytes``.
+It must stay at or below ``1.0`` for the estimate to be a genuine upper bound; a
+very small ratio instead means the estimator is over-conservative and refuses
+workloads that would have fit.
+
+Nothing here is imported by pipeline or CLI code. Benchmarks are operator-invoked
+through :mod:`smftools.machine_learning.benchmarks.sweeps`, with a small
+representative subset asserted by ``tests/integration/machine_learning``.
+"""
+
+from __future__ import annotations
+
+from .harness import (
+    BenchmarkCell,
+    BenchmarkResult,
+    EnvironmentRecord,
+    capture_environment,
+    measure,
+    write_results,
+)
+
+__all__ = [
+    "BenchmarkCell",
+    "BenchmarkResult",
+    "EnvironmentRecord",
+    "capture_environment",
+    "measure",
+    "write_results",
+]

--- a/src/smftools/machine_learning/benchmarks/_isolated.py
+++ b/src/smftools/machine_learning/benchmarks/_isolated.py
@@ -1,0 +1,154 @@
+"""Cold-allocator memory measurement runner (ML-700).
+
+Invoked as ``python -m smftools.machine_learning.benchmarks._isolated <json>``.
+
+Why a subprocess exists at all: RSS delta measured in-process systematically
+*under*-reports peak allocation once CPython's allocator holds a warm arena.
+A warmed-up repeat can satisfy a multi-megabyte NumPy allocation without the
+process RSS growing at all, so the measured peak collapses toward zero and the
+estimator looks far safer than it is. Under-reporting is the dangerous
+direction for a guardrail, so memory cells are measured once, in a fresh
+process, with no warmup.
+
+Timing is not measured here -- a cold process pays import and page-cache costs
+that would swamp the signal. ``harness.measure`` keeps that job.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(json.dumps({"error": "expected one JSON argument"}))
+        return 2
+
+    request = json.loads(argv[1])
+    mode = request["mode"]
+    workspace = Path(request["workspace"])
+
+    # Imported inside main so the JSON error path above stays cheap.
+    from ..data.partition_dataset import MLMemoryBudgetError, PartitionReadPolicy
+    from .fixtures import FixtureSpec, build_fixture
+    from .harness import _RSSWatchdog
+
+    spec = FixtureSpec(
+        n_rows=request["n_rows"],
+        n_positions=request["n_positions"],
+        n_channels=request["n_channels"],
+        n_partitions=request.get("n_partitions", 1),
+        seed=request.get("seed", 0),
+    )
+
+    policy = None
+    if request.get("max_materialization_bytes") is not None:
+        policy = PartitionReadPolicy(
+            max_materialization_bytes=int(request["max_materialization_bytes"])
+        )
+
+    # Init-separation control. One-time costs -- Zarr codec registration, AnnData
+    # machinery, pandas index types -- are paid by the first read in a process
+    # and would otherwise be attributed to the measured cell's peak, inflating
+    # the apparent fixed overhead. A discarded read against a trivial store pays
+    # them before the baseline is taken. Requested explicitly so the difference
+    # between prewarmed and cold runs is itself measurable.
+    if request.get("prewarm"):
+        probe_spec = FixtureSpec(n_rows=10, n_positions=8, n_channels=spec.n_channels)
+        probe = build_fixture(workspace / "_prewarm", probe_spec)
+        probe.dataset.materialize("train")
+        del probe
+
+    built = build_fixture(workspace, spec, policy=policy)
+    plan = built.plan
+    split = request.get("split", "train")
+
+    if mode == "materialize":
+        estimate = plan.estimate_materialization_bytes(split)
+
+        def operation() -> None:
+            built.dataset.materialize(split)
+
+    elif mode == "iter_batches":
+        estimate = plan.estimate_batch_bytes(plan.effective_batch_size)
+
+        def operation() -> None:
+            for batch in built.dataset.iter_batches(split):
+                # Touch values so lazy decoding cannot be elided.
+                int(batch.values.shape[0])
+
+    elif mode == "trajectory":
+        # Per-batch RSS after each decoded batch. Peak RSS is a high-water mark
+        # and therefore useless for deciding whether a streaming read is
+        # bounded: freed pages are not returned to the OS, so the mark rises
+        # with the *number* of allocations even when one batch is ever live.
+        # The trajectory separates the two -- accumulation grows linearly at
+        # roughly the batch size forever, while an allocator arena decelerates
+        # toward a plateau.
+        import gc
+
+        import psutil
+
+        estimate = plan.estimate_batch_bytes(plan.effective_batch_size)
+        process = psutil.Process()
+        gc.collect()
+        trajectory_baseline = int(process.memory_info().rss)
+        trajectory: list[int] = []
+        for batch in built.dataset.iter_batches(split):
+            int(batch.values.shape[0])
+            trajectory.append(int(process.memory_info().rss) - trajectory_baseline)
+        gc.collect()
+        print(
+            json.dumps(
+                {
+                    "peak_rss_delta": max(trajectory) if trajectory else 0,
+                    "baseline_rss": trajectory_baseline,
+                    "estimated_bytes": estimate,
+                    "bytes_per_row": plan.bytes_per_row,
+                    "effective_batch_size": plan.effective_batch_size,
+                    "split_counts": dict(built.split_counts),
+                    "refused": False,
+                    "refusal_message": None,
+                    "prewarm": bool(request.get("prewarm")),
+                    "trajectory": trajectory,
+                    "rss_after_collect": int(process.memory_info().rss) - trajectory_baseline,
+                }
+            )
+        )
+        return 0
+
+    else:
+        print(json.dumps({"error": f"unknown mode {mode!r}"}))
+        return 2
+
+    refused = False
+    message = None
+    with _RSSWatchdog() as watchdog:
+        try:
+            operation()
+        except MLMemoryBudgetError as exc:
+            refused = True
+            message = str(exc)
+
+    print(
+        json.dumps(
+            {
+                "peak_rss_delta": watchdog.delta,
+                "baseline_rss": watchdog.baseline,
+                "estimated_bytes": estimate,
+                "bytes_per_row": plan.bytes_per_row,
+                "effective_batch_size": plan.effective_batch_size,
+                "split_counts": dict(built.split_counts),
+                "refused": refused,
+                "refusal_message": message,
+                "prewarm": bool(request.get("prewarm")),
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    raise SystemExit(main(sys.argv))

--- a/src/smftools/machine_learning/benchmarks/fixtures.py
+++ b/src/smftools/machine_learning/benchmarks/fixtures.py
@@ -1,0 +1,402 @@
+"""Parameterized real partition stores for ML-700.
+
+Generalized from ``tests/integration/machine_learning/test_partition_dataset.py``.
+Deliberately writes through :func:`smftools.informatics.partition_store.write_experiment_store`
+rather than fabricating arrays, so benchmarks measure genuine Zarr projection and
+AnnData conversion costs -- the things the analytic estimator is trying to bound.
+
+Splits are resolved through the real :class:`SplitManifest` machinery on whole
+sample groups. Group-disjointness is enforced there, so a benchmark physically
+cannot assemble a leaky split to make itself faster.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from smftools.informatics.molecule_identity import molecule_uid
+from smftools.informatics.partition_store import write_experiment_store
+from smftools.machine_learning.contracts import InputSchema, LabelSchema
+from smftools.machine_learning.data.partition_dataset import (
+    ExperimentPartitionSource,
+    MLPartitionDataPlan,
+    PartitionDataset,
+    PartitionReadPolicy,
+    build_partition_data_plan,
+)
+from smftools.machine_learning.manifests import (
+    DatasetObservation,
+    DatasetSelection,
+    DatasetSnapshotManifest,
+    ExperimentSource,
+    GenomicInterval,
+    SourceArtifactReference,
+    SplitManifest,
+)
+from smftools.machine_learning.plan import parse_ml_plan
+from smftools.readwrite import safe_read_h5ad, safe_write_h5ad
+
+# The physical reference strand written into the store. Design-site var columns
+# are looked up as f"{Reference_strand}_{site_context}_site", so this name and
+# the var column prefixes must agree.
+PHYSICAL_REFERENCE = "ref_top"
+
+# The logical reference carried by the dataset manifest. Decoupled from the
+# physical strand on purpose -- partition_dataset prefers obs Reference_strand
+# when resolving design columns.
+LOGICAL_REFERENCE = "locus"
+
+# Fraction of sample groups assigned to each role. Groups, never rows.
+TRAIN_GROUPS = 6
+VALIDATION_GROUPS = 2
+TEST_GROUPS = 2
+TOTAL_GROUPS = TRAIN_GROUPS + VALIDATION_GROUPS + TEST_GROUPS
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    """One benchmark fixture shape."""
+
+    n_rows: int
+    n_positions: int
+    n_channels: int
+    n_partitions: int = 1
+    seed: int = 0
+    missing_fraction: float = 0.3
+
+    def __post_init__(self) -> None:
+        if self.n_rows < TOTAL_GROUPS:
+            raise ValueError(f"n_rows must be at least {TOTAL_GROUPS} to fill every split role")
+        if self.n_positions < 1:
+            raise ValueError("n_positions must be positive")
+        if self.n_channels not in {1, 2}:
+            raise ValueError("n_channels must be 1 (deaminase) or 2 (conversion)")
+        if self.n_partitions < 1:
+            raise ValueError("n_partitions must be positive")
+        if self.n_rows % self.n_partitions:
+            raise ValueError("n_rows must divide evenly across partitions")
+
+    @property
+    def modality(self) -> str:
+        return "deaminase" if self.n_channels == 1 else "conversion"
+
+    @property
+    def label(self) -> str:
+        return (
+            f"rows{self.n_rows}_pos{self.n_positions}_ch{self.n_channels}_part{self.n_partitions}"
+        )
+
+
+@dataclass(frozen=True)
+class BuiltFixture:
+    """A ready partition dataset plus the manifests behind it."""
+
+    spec: FixtureSpec
+    dataset: PartitionDataset
+    plan: MLPartitionDataPlan
+    snapshot: DatasetSnapshotManifest
+    split: SplitManifest
+    split_counts: Mapping[str, int]
+
+
+def _site_columns(n_positions: int, n_channels: int) -> dict[str, np.ndarray]:
+    positions = np.arange(n_positions)
+    if n_channels == 1:
+        # Every third position is a C site: dense enough to exercise projection,
+        # sparse enough to leave genuine non-design gaps.
+        return {f"{PHYSICAL_REFERENCE}_C_site": positions % 3 == 1}
+    return {
+        f"{PHYSICAL_REFERENCE}_GpC_site": positions % 4 == 1,
+        f"{PHYSICAL_REFERENCE}_CpG_site": positions % 4 == 2,
+    }
+
+
+def _layers(
+    rng: np.random.Generator,
+    n_rows: int,
+    n_positions: int,
+    n_channels: int,
+    missing_fraction: float,
+) -> dict[str, np.ndarray]:
+    def draw() -> np.ndarray:
+        values = rng.integers(0, 2, size=(n_rows, n_positions)).astype(np.float32)
+        missing = rng.random(size=(n_rows, n_positions)) < missing_fraction
+        values[missing] = np.nan
+        return values
+
+    if n_channels == 1:
+        return {"C_site_binary": draw()}
+    return {"GpC_site_binary": draw(), "CpG_site_binary": draw()}
+
+
+def _write_partition(
+    root: Path,
+    *,
+    experiment: str,
+    modality: str,
+    read_ids: Sequence[str],
+    sample_ids: Sequence[str],
+    n_positions: int,
+    n_channels: int,
+    rng: np.random.Generator,
+    missing_fraction: float,
+) -> Path:
+    n_rows = len(read_ids)
+    obs = pd.DataFrame(
+        {
+            "Reference_strand": pd.Categorical([PHYSICAL_REFERENCE] * n_rows),
+            "Sample": pd.Categorical(list(sample_ids)),
+        },
+        index=list(read_ids),
+    )
+    source = ad.AnnData(
+        X=np.zeros((n_rows, n_positions), dtype=np.float32),
+        obs=obs,
+        layers=_layers(rng, n_rows, n_positions, n_channels, missing_fraction),
+    )
+    source.var_names = [str(position) for position in range(n_positions)]
+    for column, values in _site_columns(n_positions, n_channels).items():
+        source.var[column] = values
+
+    paths = write_experiment_store(source, root, experiment=experiment, modality=modality)
+    spine, _ = safe_read_h5ad(paths["spine"], verbose=False)
+    spine.obs["reference_start"] = np.zeros(spine.n_obs, dtype=np.int64)
+    spine.obs["reference_end"] = np.full(spine.n_obs, n_positions, dtype=np.int64)
+    safe_write_h5ad(spine, paths["spine"], backup=False, verbose=False)
+    return paths["spine"]
+
+
+def _plan_document(modality: str, n_channels: int) -> dict[str, Any]:
+    if n_channels == 1:
+        channels = [
+            {
+                "name": "accessibility",
+                "biological_role": "accessibility",
+                "sources": [
+                    {
+                        "modality": "deaminase",
+                        "stage": "preprocess",
+                        "layer": "C_site_binary",
+                        "site_context": "C",
+                    }
+                ],
+            }
+        ]
+    else:
+        channels = [
+            {
+                "name": "accessibility",
+                "biological_role": "accessibility",
+                "sources": [
+                    {
+                        "modality": "conversion",
+                        "stage": "preprocess",
+                        "layer": "GpC_site_binary",
+                        "site_context": "GpC",
+                    }
+                ],
+            },
+            {
+                "name": "endogenous_methylation",
+                "biological_role": "endogenous_methylation",
+                "sources": [
+                    {
+                        "modality": "conversion",
+                        "stage": "preprocess",
+                        "layer": "CpG_site_binary",
+                        "site_context": "CpG",
+                    }
+                ],
+            },
+        ]
+    return {
+        "schema_version": 1,
+        "scope": {"kind": "project"},
+        "datasets": {
+            "reads": {
+                "modalities": [modality],
+                # Each fixture holds one modality across N partitions, so the
+                # union policy (reserved for multi-modality datasets) does not
+                # apply here.
+                "channel_policy": "single_modality",
+                "channels": channels,
+                "labels": {"column": "activity", "classes": {"inactive": 0, "active": 1}},
+            }
+        },
+        "splits": {
+            "groups": {
+                "strategy": "explicit_groups",
+                "group_by": ["sample_id"],
+                "train_groups": [f"sample-{index}" for index in range(TRAIN_GROUPS)],
+                "validation_groups": [
+                    f"sample-{index}"
+                    for index in range(TRAIN_GROUPS, TRAIN_GROUPS + VALIDATION_GROUPS)
+                ],
+                "test_groups": [
+                    f"sample-{index}"
+                    for index in range(TRAIN_GROUPS + VALIDATION_GROUPS, TOTAL_GROUPS)
+                ],
+            }
+        },
+        "models": {"nb": {"backend": "sklearn", "family": "bernoulli_nb"}},
+        "jobs": {
+            "train": {"action": "train", "dataset": "reads", "split": "groups", "models": ["nb"]}
+        },
+    }
+
+
+def _role_for_group(group_index: int) -> str:
+    if group_index < TRAIN_GROUPS:
+        return "train"
+    if group_index < TRAIN_GROUPS + VALIDATION_GROUPS:
+        return "validation"
+    return "test"
+
+
+def build_fixture(
+    root: Path,
+    spec: FixtureSpec,
+    *,
+    policy: PartitionReadPolicy | None = None,
+) -> BuiltFixture:
+    """Write ``spec`` as real partition stores and bind a read plan over them."""
+    rng = np.random.default_rng(spec.seed)
+    modality = spec.modality
+    rows_per_partition = spec.n_rows // spec.n_partitions
+
+    experiment_uids = [
+        str(uuid.UUID(int=(spec.seed << 16) + index)) for index in range(spec.n_partitions)
+    ]
+
+    spines: list[Path] = []
+    observations: list[DatasetObservation] = []
+    sources: list[ExperimentSource] = []
+    partition_sources: list[ExperimentPartitionSource] = []
+
+    for partition, experiment_uid in enumerate(experiment_uids):
+        read_ids = [f"p{partition}-read-{index:07d}" for index in range(rows_per_partition)]
+        # Group assignment is round-robin over sample groups so every partition
+        # contributes to every role; the role itself is a property of the group.
+        group_indices = [
+            (partition * rows_per_partition + index) % TOTAL_GROUPS
+            for index in range(rows_per_partition)
+        ]
+        sample_ids = [f"sample-{group}" for group in group_indices]
+
+        spine = _write_partition(
+            root / f"partition-{partition}",
+            experiment=f"{modality}-experiment-{partition}",
+            modality=modality,
+            read_ids=read_ids,
+            sample_ids=sample_ids,
+            n_positions=spec.n_positions,
+            n_channels=spec.n_channels,
+            rng=rng,
+            missing_fraction=spec.missing_fraction,
+        )
+        spines.append(spine)
+
+        sources.append(
+            ExperimentSource(
+                experiment_id=f"{modality}-experiment-{partition}",
+                experiment_uid=experiment_uid,
+                modality=modality,
+                stage="preprocess",
+                stage_generation_id="generation-1",
+                membership_fingerprint=f"{modality}-{partition}-members",
+                feature_fingerprint=f"{modality}-{partition}-features",
+                artifacts=(
+                    SourceArtifactReference(
+                        artifact_id=f"{modality}-{partition}-spine",
+                        kind="spine",
+                        relative_path="preprocess_outputs/spine.h5ad",
+                        sha256=f"{partition:064d}",
+                    ),
+                ),
+            )
+        )
+        partition_sources.append(
+            ExperimentPartitionSource(
+                experiment_uid=experiment_uid,
+                modality=modality,
+                stage_spines={"preprocess": spine},
+            )
+        )
+        observations.extend(
+            DatasetObservation(
+                molecule_uid=molecule_uid(experiment_uid, read_id),
+                experiment_uid=experiment_uid,
+                read_id=read_id,
+                sample_id=sample_id,
+                reference=LOGICAL_REFERENCE,
+                modality=modality,
+                # Label is a deterministic function of the group, never of the
+                # split role, so no benchmark can shortcut prediction.
+                class_id=group % 2,
+                group_values={},
+            )
+            for read_id, sample_id, group in zip(read_ids, sample_ids, group_indices, strict=True)
+        )
+
+    plan_document = parse_ml_plan(_plan_document(modality, spec.n_channels))
+    dataset_spec = plan_document.datasets["reads"]
+
+    snapshot = DatasetSnapshotManifest.create(
+        selection=DatasetSelection(
+            scope_kind="project",
+            scope_id="benchmark",
+            set_name=None,
+            dataset_name="reads",
+            plan_hash=plan_document.plan_hash,
+            samples=tuple(f"sample-{index}" for index in range(TOTAL_GROUPS)),
+            references=(LOGICAL_REFERENCE,),
+            intervals=(GenomicInterval(LOGICAL_REFERENCE, 0, spec.n_positions),),
+            filters={},
+        ),
+        input_schema=InputSchema.from_dataset(
+            dataset_spec,
+            reference=LOGICAL_REFERENCE,
+            n_positions=spec.n_positions,
+        ),
+        label_schema=LabelSchema.from_plan_label(dataset_spec.labels),
+        sources=sources,
+        observations=observations,
+    )
+
+    assignments = {
+        observation.molecule_uid: _role_for_group(int(str(observation.sample_id).rsplit("-", 1)[1]))
+        for observation in observations
+    }
+    split = SplitManifest.create(
+        dataset=snapshot,
+        group_by=("sample_id",),
+        assignments=assignments,
+    )
+
+    read_plan = build_partition_data_plan(
+        snapshot,
+        split,
+        partition_sources,
+        policy=policy or PartitionReadPolicy(),
+    )
+
+    counts: dict[str, int] = {}
+    for role in assignments.values():
+        counts[role] = counts.get(role, 0) + 1
+
+    return BuiltFixture(
+        spec=spec,
+        dataset=PartitionDataset(read_plan),
+        plan=read_plan,
+        snapshot=snapshot,
+        split=split,
+        split_counts=counts,
+    )

--- a/src/smftools/machine_learning/benchmarks/harness.py
+++ b/src/smftools/machine_learning/benchmarks/harness.py
@@ -1,0 +1,518 @@
+"""Measurement primitives for ML-700: RSS sampling, repeats, and result records.
+
+Records follow the JSONL conventions of :mod:`smftools.perf_log` -- one JSON
+object per line -- so existing tooling can read them. The ``PerfLogger``
+ContextVar itself is deliberately not reused: it is bound to stage logging and
+would tie a benchmark run to a live pipeline stage.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import platform
+import sys
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+# Sampling interval for the RSS watchdog. Fast enough to catch a transient
+# concatenation spike, slow enough not to perturb what it measures.
+RSS_SAMPLE_SECONDS = 0.02
+
+# One discarded warmup pays import, page-cache, and lazy-init costs.
+DEFAULT_WARMUP = 1
+DEFAULT_REPEATS = 3
+
+# A cell whose spread exceeds this fraction of its median is reported unstable
+# rather than silently averaged into the published limits.
+UNSTABLE_SPREAD_FRACTION = 0.20
+
+
+class BenchmarkError(RuntimeError):
+    """Raised when a benchmark cell cannot be measured meaningfully."""
+
+
+@dataclass(frozen=True)
+class BenchmarkCell:
+    """One point in the qualification matrix."""
+
+    sweep: str
+    name: str
+    parameters: Mapping[str, Any]
+    estimated_bytes: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sweep": self.sweep,
+            "name": self.name,
+            "parameters": dict(self.parameters),
+            "estimated_bytes": self.estimated_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class EnvironmentRecord:
+    """Everything needed to reproduce or discount a measurement."""
+
+    python: str
+    platform: str
+    machine: str
+    cpu_count: int
+    total_memory_bytes: int
+    numpy: str
+    sklearn: str | None
+    torch: str | None
+    torch_devices: tuple[str, ...]
+    git_commit: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "python": self.python,
+            "platform": self.platform,
+            "machine": self.machine,
+            "cpu_count": self.cpu_count,
+            "total_memory_bytes": self.total_memory_bytes,
+            "numpy": self.numpy,
+            "sklearn": self.sklearn,
+            "torch": self.torch,
+            "torch_devices": list(self.torch_devices),
+            "git_commit": self.git_commit,
+        }
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Measured outcome for one cell across its repeats."""
+
+    cell: BenchmarkCell
+    state: str  # supported | slow | refused | error
+    seconds: tuple[float, ...]
+    peak_rss_deltas: tuple[int, ...]
+    rows: int | None = None
+    refusal_message: str | None = None
+    error: str | None = None
+    notes: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def median_seconds(self) -> float | None:
+        return _median(self.seconds)
+
+    @property
+    def median_peak_bytes(self) -> int | None:
+        value = _median(self.peak_rss_deltas)
+        return int(value) if value is not None else None
+
+    @property
+    def headroom(self) -> float | None:
+        """Measured peak as a fraction of the analytic estimate.
+
+        ``<= 1.0`` means the estimate bounded reality. ``None`` when the cell was
+        refused or carries no estimate -- a refused cell never allocates, so its
+        peak is not comparable to an estimate it never used.
+        """
+        estimate = self.cell.estimated_bytes
+        peak = self.median_peak_bytes
+        if not estimate or peak is None:
+            return None
+        return peak / estimate
+
+    @property
+    def rows_per_second(self) -> float | None:
+        median = self.median_seconds
+        if self.rows is None or median is None or median <= 0:
+            return None
+        return self.rows / median
+
+    @property
+    def unstable(self) -> bool:
+        """True when repeat spread is too wide to publish as a limit."""
+        median = self.median_seconds
+        if median is None or median <= 0 or len(self.seconds) < 2:
+            return False
+        return (max(self.seconds) - min(self.seconds)) / median > UNSTABLE_SPREAD_FRACTION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self.cell.to_dict(),
+            "state": self.state,
+            "seconds": list(self.seconds),
+            "median_seconds": self.median_seconds,
+            "peak_rss_deltas": list(self.peak_rss_deltas),
+            "median_peak_bytes": self.median_peak_bytes,
+            "headroom": self.headroom,
+            "rows": self.rows,
+            "rows_per_second": self.rows_per_second,
+            "unstable": self.unstable,
+            "refusal_message": self.refusal_message,
+            "error": self.error,
+            "notes": dict(self.notes),
+        }
+
+
+def _median(values: tuple[float, ...] | tuple[int, ...]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return float(ordered[middle])
+    return (ordered[middle - 1] + ordered[middle]) / 2.0
+
+
+class _RSSWatchdog:
+    """Samples process RSS on a thread and retains the peak above a baseline."""
+
+    def __init__(self, interval: float = RSS_SAMPLE_SECONDS) -> None:
+        self._process = psutil.Process()
+        self._interval = interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.baseline = 0
+        self.peak = 0
+
+    def _rss(self) -> int:
+        return int(self._process.memory_info().rss)
+
+    def __enter__(self) -> _RSSWatchdog:
+        # Settle allocations from fixture construction so the delta attributes
+        # only the measured region.
+        gc.collect()
+        self.baseline = self._rss()
+        self.peak = self.baseline
+        self._thread = threading.Thread(target=self._run, name="ml700-rss", daemon=True)
+        self._thread.start()
+        return self
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            current = self._rss()
+            if current > self.peak:
+                self.peak = current
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        # One final read: a short region can finish between samples.
+        current = self._rss()
+        if current > self.peak:
+            self.peak = current
+
+    @property
+    def delta(self) -> int:
+        return max(0, self.peak - self.baseline)
+
+
+def measure(
+    cell: BenchmarkCell,
+    operation: Callable[[], Any],
+    *,
+    warmup: int = DEFAULT_WARMUP,
+    repeats: int = DEFAULT_REPEATS,
+    expect_refusal: type[BaseException] | None = None,
+    rows: int | None = None,
+    notes: Mapping[str, Any] | None = None,
+) -> BenchmarkResult:
+    """Run ``operation`` under RSS sampling and return a measured result.
+
+    ``operation`` must be self-contained and side-effect free across repeats.
+    When ``expect_refusal`` is supplied the cell is expected to raise that type;
+    raising it is recorded as ``refused`` and *not* raising is an error, because
+    a refusal boundary that silently stopped refusing is exactly the regression
+    this package exists to catch.
+    """
+    if repeats < 1:
+        raise BenchmarkError("repeats must be at least 1")
+
+    for _ in range(max(0, warmup)):
+        try:
+            operation()
+        except Exception:  # noqa: BLE001 - a refused warmup is informative, not fatal
+            break
+
+    seconds: list[float] = []
+    peaks: list[int] = []
+    refusal_message: str | None = None
+
+    for _ in range(repeats):
+        with _RSSWatchdog() as watchdog:
+            start = time.perf_counter()
+            try:
+                operation()
+            except Exception as exc:  # noqa: BLE001 - classified below
+                elapsed = time.perf_counter() - start
+                if expect_refusal is not None and isinstance(exc, expect_refusal):
+                    seconds.append(elapsed)
+                    peaks.append(watchdog.delta)
+                    refusal_message = str(exc)
+                    continue
+                return BenchmarkResult(
+                    cell=cell,
+                    state="error",
+                    seconds=tuple(seconds),
+                    peak_rss_deltas=tuple(peaks),
+                    rows=rows,
+                    error=f"{type(exc).__name__}: {exc}",
+                    notes=dict(notes or {}),
+                )
+            elapsed = time.perf_counter() - start
+        if expect_refusal is not None:
+            return BenchmarkResult(
+                cell=cell,
+                state="error",
+                seconds=tuple(seconds),
+                peak_rss_deltas=tuple(peaks),
+                rows=rows,
+                error=(
+                    f"expected {expect_refusal.__name__} but the operation succeeded; "
+                    "a refusal boundary stopped refusing"
+                ),
+                notes=dict(notes or {}),
+            )
+        seconds.append(elapsed)
+        peaks.append(watchdog.delta)
+
+    return BenchmarkResult(
+        cell=cell,
+        state="refused" if expect_refusal is not None else "supported",
+        seconds=tuple(seconds),
+        peak_rss_deltas=tuple(peaks),
+        rows=rows,
+        refusal_message=refusal_message,
+        notes=dict(notes or {}),
+    )
+
+
+def measure_memory_isolated(
+    cell: BenchmarkCell,
+    request: Mapping[str, Any],
+    *,
+    workspace: Path,
+    timeout: float = 1800.0,
+) -> BenchmarkResult:
+    """Measure peak allocation for one cell in a fresh process.
+
+    In-process RSS delta under-reports peak allocation once CPython's allocator
+    holds a warm arena -- a repeat can satisfy a multi-megabyte NumPy allocation
+    with no RSS growth at all. Under-reporting makes a memory guardrail look
+    safer than it is, so memory cells get a cold process, measured once, with no
+    warmup. See ``_isolated``.
+    """
+    import subprocess
+
+    payload = dict(request)
+    payload["workspace"] = str(workspace)
+    command = [
+        sys.executable,
+        "-m",
+        "smftools.machine_learning.benchmarks._isolated",
+        json.dumps(payload),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return BenchmarkResult(
+            cell=cell,
+            state="error",
+            seconds=(),
+            peak_rss_deltas=(),
+            error=f"isolated measurement exceeded {timeout}s",
+        )
+
+    stdout = completed.stdout.strip().splitlines()
+    record: dict[str, Any] | None = None
+    for line in reversed(stdout):
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        record = candidate
+        break
+
+    if record is None or "peak_rss_delta" not in record:
+        detail = record.get("error") if isinstance(record, dict) else completed.stderr.strip()
+        return BenchmarkResult(
+            cell=cell,
+            state="error",
+            seconds=(),
+            peak_rss_deltas=(),
+            error=f"isolated measurement produced no result: {detail or 'no output'}",
+        )
+
+    measured_cell = BenchmarkCell(
+        sweep=cell.sweep,
+        name=cell.name,
+        parameters={**dict(cell.parameters), "bytes_per_row": record.get("bytes_per_row")},
+        estimated_bytes=int(record["estimated_bytes"]),
+    )
+    return BenchmarkResult(
+        cell=measured_cell,
+        state="refused" if record.get("refused") else "supported",
+        seconds=(),
+        peak_rss_deltas=(int(record["peak_rss_delta"]),),
+        rows=record.get("split_counts", {}).get(request.get("split", "train")),
+        refusal_message=record.get("refusal_message"),
+        notes={
+            "isolated": True,
+            "baseline_rss": record.get("baseline_rss"),
+            "split_counts": record.get("split_counts", {}),
+        },
+    )
+
+
+def measure_memory_repeated(
+    cell: BenchmarkCell,
+    request: Mapping[str, Any],
+    *,
+    workspace: Path,
+    repeats: int = 5,
+    timeout: float = 1800.0,
+) -> BenchmarkResult:
+    """Run ``repeats`` independent cold processes and aggregate their peaks.
+
+    Each repeat is a fresh interpreter, so the repeats are genuinely independent
+    samples rather than successive reads of one warming process. Cold-process
+    RSS is page-granular and lumpy, so a single sample cannot support a claim
+    about the estimator; this is the function that produces publishable numbers.
+
+    The reported ``headroom`` uses the **maximum** observed peak, not the median.
+    A memory bound is a worst-case claim: an estimator that covers the typical
+    run but not the worst run is not a bound.
+    """
+    if repeats < 1:
+        raise BenchmarkError("repeats must be at least 1")
+
+    peaks: list[int] = []
+    estimate: int | None = None
+    rows: int | None = None
+    refusal_message: str | None = None
+    refused = False
+    bytes_per_row: int | None = None
+
+    for index in range(repeats):
+        attempt = measure_memory_isolated(
+            cell,
+            request,
+            workspace=workspace / f"repeat-{index}",
+            timeout=timeout,
+        )
+        if attempt.state == "error":
+            return BenchmarkResult(
+                cell=cell,
+                state="error",
+                seconds=(),
+                peak_rss_deltas=tuple(peaks),
+                error=f"repeat {index}: {attempt.error}",
+            )
+        peaks.extend(attempt.peak_rss_deltas)
+        estimate = attempt.cell.estimated_bytes
+        bytes_per_row = attempt.cell.parameters.get("bytes_per_row")
+        rows = attempt.rows
+        refused = refused or attempt.state == "refused"
+        refusal_message = refusal_message or attempt.refusal_message
+
+    measured_cell = BenchmarkCell(
+        sweep=cell.sweep,
+        name=cell.name,
+        parameters={**dict(cell.parameters), "bytes_per_row": bytes_per_row, "repeats": repeats},
+        estimated_bytes=estimate,
+    )
+    worst = max(peaks) if peaks else None
+    return BenchmarkResult(
+        cell=measured_cell,
+        state="refused" if refused else "supported",
+        seconds=(),
+        peak_rss_deltas=tuple(peaks),
+        rows=rows,
+        refusal_message=refusal_message,
+        notes={
+            "isolated": True,
+            "repeats": repeats,
+            "worst_peak_bytes": worst,
+            "worst_headroom": (worst / estimate) if (worst and estimate) else None,
+            "prewarm": bool(request.get("prewarm")),
+        },
+    )
+
+
+def capture_environment() -> EnvironmentRecord:
+    """Record interpreter, library, device, and host state for reproducibility."""
+    import numpy as np
+
+    sklearn_version: str | None
+    try:
+        import sklearn
+
+        sklearn_version = sklearn.__version__
+    except Exception:  # noqa: BLE001 - sklearn is core but must not break capture
+        sklearn_version = None
+
+    torch_version: str | None
+    devices: list[str] = ["cpu"]
+    try:
+        import torch
+
+        torch_version = torch.__version__
+        if torch.cuda.is_available():
+            devices.append("cuda")
+        if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+            devices.append("mps")
+    except Exception:  # noqa: BLE001 - torch is optional at capture time
+        torch_version = None
+
+    return EnvironmentRecord(
+        python=sys.version.split()[0],
+        platform=platform.platform(),
+        machine=platform.machine(),
+        cpu_count=psutil.cpu_count(logical=True) or 0,
+        total_memory_bytes=int(psutil.virtual_memory().total),
+        numpy=np.__version__,
+        sklearn=sklearn_version,
+        torch=torch_version,
+        torch_devices=tuple(devices),
+        git_commit=_git_commit(),
+    )
+
+
+def _git_commit() -> str | None:
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            cwd=Path(__file__).resolve().parent,
+        )
+    except Exception:  # noqa: BLE001 - benchmarks must run outside a checkout
+        return None
+    return result.stdout.strip() or None
+
+
+def write_results(
+    path: str | Path,
+    results: list[BenchmarkResult],
+    environment: EnvironmentRecord,
+) -> Path:
+    """Write one JSONL file: an environment header line, then one line per cell."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps({"record": "environment", **environment.to_dict()}) + "\n")
+        for result in results:
+            handle.write(json.dumps({"record": "cell", **result.to_dict()}) + "\n")
+    return destination

--- a/src/smftools/machine_learning/benchmarks/sweeps.py
+++ b/src/smftools/machine_learning/benchmarks/sweeps.py
@@ -1,0 +1,484 @@
+"""ML-700 sweeps.
+
+Implemented here:
+
+- :func:`sweep_memory_calibration` (Sweep A) -- the core deliverable. Measures
+  peak RSS against the analytic estimate for bounded batch reads and for full
+  materialization, producing the headroom distribution.
+- :func:`sweep_refusal_boundary` -- confirms ``MLMemoryBudgetError`` fires
+  exactly where the closed form predicts, and that refusal happens at preflight
+  without allocating.
+- :func:`sweep_worker_scaling` (Sweep C) -- per-shard throughput and bounded
+  per-worker peak.
+
+Sweep B (backend throughput across sklearn/Torch and cpu/mps) and Sweep D
+(explanation chunk sizing) are specified in ``dev/in-progress/ml700_benchmark_plan.md``
+and are not implemented yet.
+
+Refusal cells deliberately run against a *reduced* ``max_materialization_bytes``
+rather than building a 50,000-row store. The refusal predicate is
+``estimate > budget``; scaling the budget down exercises the identical code path
+and the identical formula at a fraction of the cost, and the boundary is asserted
+against the closed form rather than against a hardcoded row count.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from smftools.machine_learning.data.partition_dataset import (
+    MLMemoryBudgetError,
+    PartitionReadPolicy,
+)
+
+from .fixtures import FixtureSpec, build_fixture
+from .harness import (
+    BenchmarkCell,
+    BenchmarkResult,
+    measure,
+    measure_memory_repeated,
+)
+
+# Sweep A levels. Rows straddle the materialization frontier; positions span a
+# single locus through a full amplicon panel.
+CALIBRATION_ROWS = (500, 5_000, 50_000)
+CALIBRATION_POSITIONS = (500, 1_000, 5_000, 20_000)
+CALIBRATION_CHANNELS = (1, 2)
+
+# The CI subset: small enough to run on every push, wide enough to catch a
+# changed estimator constant.
+CI_ROWS = (500,)
+CI_POSITIONS = (500, 1_000)
+CI_CHANNELS = (1, 2)
+
+WORKER_COUNTS = (1, 2, 4, 8)
+
+
+def _consume_batches(dataset, split: str, **kwargs) -> int:
+    rows = 0
+    for batch in dataset.iter_batches(split, **kwargs):
+        # Touch the values so lazy decoding cannot be skipped.
+        rows += int(batch.values.shape[0])
+    return rows
+
+
+def sweep_memory_calibration(
+    *,
+    rows: Sequence[int] = CALIBRATION_ROWS,
+    positions: Sequence[int] = CALIBRATION_POSITIONS,
+    channels: Sequence[int] = CALIBRATION_CHANNELS,
+    repeats: int = 3,
+    warmup: int = 1,
+    root: Path | None = None,
+) -> list[BenchmarkResult]:
+    """Measure peak RSS against the analytic estimate for reads and materialization."""
+    results: list[BenchmarkResult] = []
+    for n_rows in rows:
+        for n_positions in positions:
+            for n_channels in channels:
+                spec = FixtureSpec(
+                    n_rows=n_rows,
+                    n_positions=n_positions,
+                    n_channels=n_channels,
+                )
+                results.extend(
+                    _calibration_cells(
+                        spec,
+                        repeats=repeats,
+                        warmup=warmup,
+                        root=root,
+                    )
+                )
+    return results
+
+
+def _calibration_cells(
+    spec: FixtureSpec,
+    *,
+    repeats: int,
+    warmup: int,
+    root: Path | None,
+) -> list[BenchmarkResult]:
+    with _workspace(root) as workspace:
+        built = build_fixture(workspace, spec)
+        plan = built.plan
+        train_rows = built.split_counts.get("train", 0)
+
+        batch_estimate = plan.estimate_batch_bytes(plan.effective_batch_size)
+        batch_cell = BenchmarkCell(
+            sweep="A",
+            name=f"batch_read_{spec.label}",
+            parameters={
+                "n_rows": spec.n_rows,
+                "n_positions": spec.n_positions,
+                "n_channels": spec.n_channels,
+                "n_partitions": spec.n_partitions,
+                "batch_size": plan.effective_batch_size,
+                "bytes_per_row": plan.bytes_per_row,
+                "mode": "iter_batches",
+            },
+            estimated_bytes=batch_estimate,
+        )
+        batch_result = measure(
+            batch_cell,
+            lambda: _consume_batches(built.dataset, "train"),
+            repeats=repeats,
+            warmup=warmup,
+            rows=train_rows,
+            notes={"split_counts": dict(built.split_counts)},
+        )
+
+        materialization_estimate = plan.estimate_materialization_bytes("train")
+        budget = plan.policy.max_materialization_bytes
+        refuses = materialization_estimate > budget
+        materialize_cell = BenchmarkCell(
+            sweep="A",
+            name=f"materialize_{spec.label}",
+            parameters={
+                "n_rows": spec.n_rows,
+                "n_positions": spec.n_positions,
+                "n_channels": spec.n_channels,
+                "n_partitions": spec.n_partitions,
+                "bytes_per_row": plan.bytes_per_row,
+                "budget_bytes": budget,
+                "mode": "materialize",
+            },
+            estimated_bytes=materialization_estimate,
+        )
+        materialize_result = measure(
+            materialize_cell,
+            lambda: built.dataset.materialize("train"),
+            repeats=repeats,
+            warmup=0 if refuses else warmup,
+            rows=train_rows,
+            expect_refusal=MLMemoryBudgetError if refuses else None,
+            notes={"predicted_refusal": refuses},
+        )
+
+    return [batch_result, materialize_result]
+
+
+def sweep_memory_repeated(
+    *,
+    rows: Sequence[int] = CI_ROWS,
+    positions: Sequence[int] = CI_POSITIONS,
+    channels: Sequence[int] = CI_CHANNELS,
+    modes: Sequence[str] = ("iter_batches", "materialize"),
+    repeats: int = 5,
+    prewarm: bool = True,
+    root: Path | None = None,
+) -> list[BenchmarkResult]:
+    """Sweep A with N independent cold processes per cell.
+
+    This is the publishable variant. :func:`sweep_memory_calibration` measures
+    timing in-process and is retained for throughput; its memory readings are
+    biased low by allocator warmth and must not be quoted as limits.
+    """
+    results: list[BenchmarkResult] = []
+    with _workspace(root) as workspace:
+        for n_rows in rows:
+            for n_positions in positions:
+                for n_channels in channels:
+                    for mode in modes:
+                        label = f"rows{n_rows}_pos{n_positions}_ch{n_channels}"
+                        cell = BenchmarkCell(
+                            sweep="A",
+                            name=f"{mode}_{label}",
+                            parameters={
+                                "n_rows": n_rows,
+                                "n_positions": n_positions,
+                                "n_channels": n_channels,
+                                "mode": mode,
+                                "prewarm": prewarm,
+                            },
+                        )
+                        results.append(
+                            measure_memory_repeated(
+                                cell,
+                                {
+                                    "mode": mode,
+                                    "n_rows": n_rows,
+                                    "n_positions": n_positions,
+                                    "n_channels": n_channels,
+                                    "prewarm": prewarm,
+                                },
+                                workspace=workspace / f"{mode}-{label}",
+                                repeats=repeats,
+                            )
+                        )
+    return results
+
+
+def sweep_bounded_batch_memory(
+    *,
+    row_counts: Sequence[int] = (500, 1_000, 2_000, 4_000),
+    n_positions: int = 500,
+    n_channels: int = 1,
+    repeats: int = 5,
+    prewarm: bool = True,
+    root: Path | None = None,
+) -> list[BenchmarkResult]:
+    """Test the bounded-memory claim directly: does batch-read peak track total rows?
+
+    ``iter_batches`` is supposed to hold at most one decoded batch regardless of
+    how many rows the split contains. If that holds, peak RSS stays flat as
+    ``row_counts`` grows and the batch estimate remains a valid bound at any
+    scale. If peak instead grows with total rows, something is accumulating
+    across batches and the whole "stream instead of materialize" guidance is
+    unsound -- which is the single most consequential thing this sweep can find.
+    """
+    results: list[BenchmarkResult] = []
+    with _workspace(root) as workspace:
+        for n_rows in row_counts:
+            cell = BenchmarkCell(
+                sweep="A-bounded",
+                name=f"iter_batches_rows{n_rows}_pos{n_positions}_ch{n_channels}",
+                parameters={
+                    "n_rows": n_rows,
+                    "n_positions": n_positions,
+                    "n_channels": n_channels,
+                    "mode": "iter_batches",
+                    "prewarm": prewarm,
+                },
+            )
+            results.append(
+                measure_memory_repeated(
+                    cell,
+                    {
+                        "mode": "iter_batches",
+                        "n_rows": n_rows,
+                        "n_positions": n_positions,
+                        "n_channels": n_channels,
+                        "prewarm": prewarm,
+                    },
+                    workspace=workspace / f"bounded-{n_rows}",
+                    repeats=repeats,
+                )
+            )
+    return results
+
+
+def measure_batch_trajectory(
+    *,
+    n_rows: int = 32_000,
+    n_positions: int = 500,
+    n_channels: int = 1,
+    prewarm: bool = True,
+    root: Path | None = None,
+    timeout: float = 3600.0,
+) -> dict[str, object]:
+    """Run one long streaming read and decide bounded vs accumulating.
+
+    Returns per-quartile growth in bytes/batch. The verdict rests on the shape,
+    not the magnitude:
+
+    - **accumulating** -- growth stays near the batch size in every quartile.
+      One batch per iteration is being retained.
+    - **bounded** -- growth decelerates toward zero. The allocator arena is
+      reaching steady state and live memory is bounded.
+
+    A long run matters because a short one cannot distinguish a plateau from the
+    early part of a linear rise.
+    """
+    import json
+    import subprocess
+    import sys
+
+    with _workspace(root) as workspace:
+        payload = {
+            "mode": "trajectory",
+            "n_rows": n_rows,
+            "n_positions": n_positions,
+            "n_channels": n_channels,
+            "prewarm": prewarm,
+            "workspace": str(workspace),
+        }
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "smftools.machine_learning.benchmarks._isolated",
+                json.dumps(payload),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    record = None
+    for line in reversed(completed.stdout.strip().splitlines()):
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        break
+    if record is None or "trajectory" not in record:
+        return {"error": completed.stderr.strip()[-2000:] or "no trajectory produced"}
+
+    trajectory = record["trajectory"]
+    n = len(trajectory)
+    if n < 8:
+        return {"error": f"trajectory too short to analyse ({n} batches)"}
+
+    quartiles = []
+    for index in range(4):
+        start = (n * index) // 4
+        end = (n * (index + 1)) // 4 - 1
+        span = max(1, end - start)
+        quartiles.append((trajectory[end] - trajectory[start]) / span)
+
+    batch_bytes = record["estimated_bytes"]
+    last = quartiles[-1]
+    first = quartiles[0]
+    # Bounded if the final quartile has decayed well below both the batch size
+    # and its own first quartile. Accumulation cannot decay: it is driven by a
+    # fresh allocation every iteration.
+    verdict = (
+        "bounded"
+        if last < 0.2 * batch_bytes and (first <= 0 or last < 0.5 * first)
+        else "accumulating"
+    )
+
+    return {
+        "batches": n,
+        "batch_estimate_bytes": batch_bytes,
+        "effective_batch_size": record["effective_batch_size"],
+        "train_rows": record["split_counts"].get("train"),
+        "quartile_bytes_per_batch": quartiles,
+        "final_rss_delta": trajectory[-1],
+        "rss_after_collect": record.get("rss_after_collect"),
+        "verdict": verdict,
+    }
+
+
+def sweep_refusal_boundary(
+    *,
+    n_positions: int = 1_000,
+    n_channels: int = 1,
+    n_rows: int = 200,
+    root: Path | None = None,
+) -> list[BenchmarkResult]:
+    """Confirm the refusal predicate fires exactly at the closed-form boundary.
+
+    Builds one fixture, then probes it with two budgets derived from its own
+    measured ``bytes_per_row``: one a single byte above the estimate (must be
+    approved) and one a single byte below (must be refused). This pins the
+    boundary to the formula rather than to a remembered row count.
+    """
+    spec = FixtureSpec(n_rows=n_rows, n_positions=n_positions, n_channels=n_channels)
+    results: list[BenchmarkResult] = []
+
+    with _workspace(root) as workspace:
+        probe = build_fixture(workspace / "probe", spec)
+        estimate = probe.plan.estimate_materialization_bytes("train")
+        train_rows = probe.split_counts.get("train", 0)
+
+        for label, budget, expect in (
+            ("at_budget", estimate, None),
+            ("above_budget", estimate + 1, None),
+            ("below_budget", estimate - 1, MLMemoryBudgetError),
+        ):
+            built = build_fixture(
+                workspace / label,
+                spec,
+                policy=PartitionReadPolicy(max_materialization_bytes=budget),
+            )
+            cell = BenchmarkCell(
+                sweep="refusal",
+                name=f"{label}_{spec.label}",
+                parameters={
+                    "n_rows": spec.n_rows,
+                    "n_positions": spec.n_positions,
+                    "n_channels": spec.n_channels,
+                    "budget_bytes": budget,
+                    "estimate_bytes": estimate,
+                    "bytes_per_row": built.plan.bytes_per_row,
+                },
+                estimated_bytes=estimate,
+            )
+            results.append(
+                measure(
+                    cell,
+                    lambda dataset=built.dataset: dataset.materialize("train"),
+                    repeats=1,
+                    warmup=0,
+                    rows=train_rows,
+                    expect_refusal=expect,
+                )
+            )
+    return results
+
+
+def sweep_worker_scaling(
+    *,
+    n_rows: int = 5_000,
+    n_positions: int = 1_000,
+    n_channels: int = 1,
+    worker_counts: Iterable[int] = WORKER_COUNTS,
+    repeats: int = 3,
+    warmup: int = 1,
+    root: Path | None = None,
+) -> list[BenchmarkResult]:
+    """Measure single-shard throughput and peak as ``num_workers`` rises.
+
+    Shards are read in-process one at a time: this measures the *per-shard*
+    bound, which is what determines whether N real workers fit in memory
+    simultaneously. It deliberately does not spawn processes -- process pool
+    behavior is `memory_guard`'s domain and is already covered there.
+    """
+    results: list[BenchmarkResult] = []
+    spec = FixtureSpec(n_rows=n_rows, n_positions=n_positions, n_channels=n_channels)
+
+    with _workspace(root) as workspace:
+        built = build_fixture(workspace, spec)
+        train_rows = built.split_counts.get("train", 0)
+
+        for num_workers in worker_counts:
+            cell = BenchmarkCell(
+                sweep="C",
+                name=f"worker_shard_{num_workers}_{spec.label}",
+                parameters={
+                    "n_rows": spec.n_rows,
+                    "n_positions": spec.n_positions,
+                    "n_channels": spec.n_channels,
+                    "num_workers": num_workers,
+                    "batch_size": built.plan.effective_batch_size,
+                },
+                estimated_bytes=built.plan.estimate_batch_bytes(built.plan.effective_batch_size),
+            )
+            results.append(
+                measure(
+                    cell,
+                    lambda workers=num_workers: _consume_batches(
+                        built.dataset, "train", worker_id=0, num_workers=workers
+                    ),
+                    repeats=repeats,
+                    warmup=warmup,
+                    rows=max(1, train_rows // num_workers),
+                    notes={"total_train_rows": train_rows},
+                )
+            )
+    return results
+
+
+class _workspace:
+    """Yield ``root`` if given, else a temporary directory removed on exit."""
+
+    def __init__(self, root: Path | None) -> None:
+        self._root = root
+        self._tmp: tempfile.TemporaryDirectory | None = None
+
+    def __enter__(self) -> Path:
+        if self._root is not None:
+            self._root.mkdir(parents=True, exist_ok=True)
+            return self._root
+        self._tmp = tempfile.TemporaryDirectory(prefix="ml700-")
+        return Path(self._tmp.name)
+
+    def __exit__(self, *exc: object) -> None:
+        if self._tmp is not None:
+            self._tmp.cleanup()
+            self._tmp = None


### PR DESCRIPTION
First of two ML-700 PRs. This lands the measurement infrastructure; the published supported/slow/refused limits follow after ML-204, because streaming training changes what those limits are.

The memory guardrails in the ML data plane are analytic and had never been compared to a measured peak: partition_dataset._bytes_per_row applies a fixed 2x transient allowance and estimate_materialization_bytes a further 3x. Those constants are the only thing between an approved read and an OOM. This harness measures the gap.

Contents:

- harness.py: benchmark cells, RSS watchdog, repeat policy, environment capture, JSONL records following perf_log conventions.
- fixtures.py: parameterized real partition stores built through write_experiment_store, not synthetic arrays. Splits resolve through the real SplitManifest, whose group-disjointness enforcement means a benchmark cannot assemble a leaky split to make itself faster.
- _isolated.py: cold-process measurement entry point.
- sweeps.py: memory calibration, refusal boundary, worker scaling, bounded batch memory, and the batch-trajectory analysis.

Two measurement findings are baked into the design, both of which produced a false result before being caught:

1. In-process RSS under-reports peak allocation once CPython's allocator holds a warm arena -- 82 KB measured for a 12 MB workload at two warmups. Memory is therefore measured once per fresh subprocess, with no warmup; timing keeps the in-process warmup path where warmup is correct.
2. Peak RSS over a streaming read over-reports, because the high-water mark accumulates freed pages. Bounded-vs-accumulating is decided by the per-batch trajectory shape instead, and run length is part of the method: 38 batches returned the wrong verdict where 300 batches showed monotonic decay to 3.8% of one batch estimate.

Verdict on the estimator: the 2x/3x constants hold and need no change. Worst-case slope is 12,950 B/row against 21,102 assumed. An earlier single-shot "invariant violated" reading was retracted as noise.

Nothing imports this package; it is operator-invoked. ML-204's acceptance criteria depend on the trajectory method it provides.

Validation: Ruff check and format clean; git diff --check clean; ML and analysis unit suites 349 passed, 7 xfailed.