### PR TITLE
Publish ML scale limits as committed data with a per-PR guard

### DIFF
--- a/src/smftools/machine_learning/benchmarks/_isolated.py
+++ b/src/smftools/machine_learning/benchmarks/_isolated.py
@@ -43,11 +43,12 @@ def main(argv: list[str]) -> int:
         seed=request.get("seed", 0),
     )
 
-    policy = None
+    policy_kwargs = {}
     if request.get("max_materialization_bytes") is not None:
-        policy = PartitionReadPolicy(
-            max_materialization_bytes=int(request["max_materialization_bytes"])
-        )
+        policy_kwargs["max_materialization_bytes"] = int(request["max_materialization_bytes"])
+    if request.get("batch_size") is not None:
+        policy_kwargs["batch_size"] = int(request["batch_size"])
+    policy = PartitionReadPolicy(**policy_kwargs) if policy_kwargs else None
 
     # Init-separation control. One-time costs -- Zarr codec registration, AnnData
     # machinery, pandas index types -- are paid by the first read in a process
@@ -114,6 +115,87 @@ def main(argv: list[str]) -> int:
                     "prewarm": bool(request.get("prewarm")),
                     "trajectory": trajectory,
                     "rss_after_collect": int(process.memory_info().rss) - trajectory_baseline,
+                }
+            )
+        )
+        return 0
+
+    elif mode == "streaming_fit":
+        # ML-204 acceptance: peak memory during a streaming *fit* must be
+        # bounded, verified with the trajectory method rather than a single peak
+        # reading. RSS is sampled as each batch leaves the reader, so the sample
+        # points sit inside the fit rather than around it.
+        import gc
+
+        import psutil
+
+        from ..data.partition_dataset import PartitionReadPolicy  # noqa: F811
+        from ..models.registry import BUILTIN_MODEL_REGISTRY
+
+        process = psutil.Process()
+        trajectory: list[int] = []
+        baseline_holder = {"value": 0}
+
+        class _Sampling:
+            """Delegates to the dataset, sampling RSS at each yielded batch."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            @property
+            def plan(self):
+                return self._inner.plan
+
+            def materialize(self, split_name):
+                raise AssertionError("a streaming fit must not materialize")
+
+            def iter_batches(self, split_name, **kwargs):
+                for item in self._inner.iter_batches(split_name, **kwargs):
+                    trajectory.append(int(process.memory_info().rss) - baseline_holder["value"])
+                    yield item
+
+        sampling = _Sampling(built.dataset)
+        backend = request.get("backend", "sklearn")
+        family = "bernoulli_nb" if backend == "sklearn" else "residual_dilated_cnn"
+        resolved = BUILTIN_MODEL_REGISTRY.resolve(family, input_schema=plan.dataset.input_schema)
+        gc.collect()
+        baseline_holder["value"] = int(process.memory_info().rss)
+
+        if backend == "sklearn":
+            from ..training.sklearn_backend import fit_sklearn_partition_model_streaming
+
+            fit_sklearn_partition_model_streaming(sampling, resolved)
+        else:
+            from ..training.torch_backend import (
+                TorchTrainingConfig,
+                fit_torch_partition_model_streaming,
+            )
+
+            fit_torch_partition_model_streaming(
+                sampling,
+                resolved,
+                training_config=TorchTrainingConfig(
+                    max_epochs=int(request.get("max_epochs", 3)),
+                    device="cpu",
+                    batch_size=plan.effective_batch_size,
+                ),
+            )
+        gc.collect()
+        print(
+            json.dumps(
+                {
+                    "peak_rss_delta": max(trajectory) if trajectory else 0,
+                    "baseline_rss": baseline_holder["value"],
+                    "estimated_bytes": plan.estimate_batch_bytes(plan.effective_batch_size),
+                    "bytes_per_row": plan.bytes_per_row,
+                    "effective_batch_size": plan.effective_batch_size,
+                    "split_counts": dict(built.split_counts),
+                    "refused": False,
+                    "refusal_message": None,
+                    "prewarm": bool(request.get("prewarm")),
+                    "backend": backend,
+                    "trajectory": trajectory,
+                    "rss_after_collect": int(process.memory_info().rss) - baseline_holder["value"],
                 }
             )
         )

--- a/src/smftools/machine_learning/benchmarks/sweeps.py
+++ b/src/smftools/machine_learning/benchmarks/sweeps.py
@@ -268,6 +268,10 @@ def measure_batch_trajectory(
     prewarm: bool = True,
     root: Path | None = None,
     timeout: float = 3600.0,
+    mode: str = "trajectory",
+    backend: str | None = None,
+    max_epochs: int = 3,
+    batch_size: int | None = None,
 ) -> dict[str, object]:
     """Run one long streaming read and decide bounded vs accumulating.
 
@@ -288,13 +292,18 @@ def measure_batch_trajectory(
 
     with _workspace(root) as workspace:
         payload = {
-            "mode": "trajectory",
+            "mode": mode,
             "n_rows": n_rows,
             "n_positions": n_positions,
             "n_channels": n_channels,
             "prewarm": prewarm,
             "workspace": str(workspace),
+            "max_epochs": max_epochs,
         }
+        if backend is not None:
+            payload["backend"] = backend
+        if batch_size is not None:
+            payload["batch_size"] = batch_size
         completed = subprocess.run(
             [
                 sys.executable,
@@ -333,16 +342,27 @@ def measure_batch_trajectory(
     batch_bytes = record["estimated_bytes"]
     last = quartiles[-1]
     first = quartiles[0]
-    # Bounded if the final quartile has decayed well below both the batch size
-    # and its own first quartile. Accumulation cannot decay: it is driven by a
-    # fresh allocation every iteration.
+    plateau = trajectory[-1]
+
+    # The criterion is plateau-relative, not batch-estimate-relative. An earlier
+    # version compared final-quartile growth to the data batch estimate, which
+    # is the wrong scale for a fit: a Torch working set is dominated by model
+    # activations, so a genuinely flat trajectory was reported as
+    # "accumulating" simply because the model is larger than one data batch.
+    # What distinguishes bounded from accumulating is whether growth has stopped
+    # relative to where it settled, plus deceleration from the first quartile --
+    # real accumulation cannot decelerate, since it allocates afresh every pass.
+    tail_fraction = (last * max(1, n // 4)) / plateau if plateau > 0 else 0.0
     verdict = (
-        "bounded"
-        if last < 0.2 * batch_bytes and (first <= 0 or last < 0.5 * first)
-        else "accumulating"
+        "bounded" if tail_fraction < 0.05 and (first <= 0 or last < 0.5 * first) else "accumulating"
     )
 
     return {
+        "mode": mode,
+        "backend": record.get("backend"),
+        "plateau_bytes": plateau,
+        "tail_growth_fraction": tail_fraction,
+        "plateau_over_batch_estimate": (plateau / batch_bytes) if batch_bytes else None,
         "batches": n,
         "batch_estimate_bytes": batch_bytes,
         "effective_batch_size": record["effective_batch_size"],
@@ -482,3 +502,118 @@ class _workspace:
         if self._tmp is not None:
             self._tmp.cleanup()
             self._tmp = None
+
+
+def measure_explanation_chunking(
+    *,
+    n_rows: int = 400,
+    n_positions: int = 400,
+    n_channels: int = 1,
+    example_batch_sizes: Sequence[int] = (1, 8, 64, 512),
+    method: str = "Saliency",
+    root: Path | None = None,
+) -> list[dict[str, object]]:
+    """Sweep D: what does ``example_batch_size`` buy, and what does it cost?
+
+    Attribution runs a forward and backward pass per chunk, so the chunk size
+    trades wall time against peak memory in the same way a training batch does.
+    Neither term is modelled by any budget in the ML data plane -- see the Torch
+    entry in ``tests/acceptance/ml_scale_thresholds.json`` -- so the guidance
+    published for chunk sizing has to be measured rather than derived.
+
+    Runs in-process: attribution is a single bounded pass, so the warm-arena
+    under-reporting that forced cold subprocesses for repeated reads does not
+    apply in the same way. Peak is still the high-water mark and is reported as
+    such.
+    """
+    import gc
+    import time
+
+    import numpy as np
+    import psutil
+
+    from smftools.machine_learning.artifacts import ExplanationMaskPolicy, ExplanationTarget
+    from smftools.machine_learning.interpretability import (
+        ExplanationDecisionProvenance,
+        InterpretabilityRequest,
+        explain_torch_model,
+    )
+    from smftools.machine_learning.models.registry import BUILTIN_MODEL_REGISTRY
+    from smftools.machine_learning.training.torch_backend import (
+        TorchTrainingConfig,
+        fit_torch_partition_model_streaming,
+    )
+
+    results: list[dict[str, object]] = []
+    process = psutil.Process()
+
+    with _workspace(root) as workspace:
+        built = build_fixture(
+            workspace,
+            FixtureSpec(
+                n_rows=n_rows,
+                n_positions=n_positions,
+                n_channels=n_channels,
+                imbalanced=True,
+            ),
+        )
+        resolved = BUILTIN_MODEL_REGISTRY.resolve(
+            "residual_dilated_cnn", input_schema=built.plan.dataset.input_schema
+        )
+        trained = fit_torch_partition_model_streaming(
+            built.dataset,
+            resolved,
+            training_config=TorchTrainingConfig(max_epochs=1, device="cpu", batch_size=32),
+        )
+        data = built.dataset.materialize("test")
+        mask_kinds = tuple(
+            mask.kind
+            for mask in trained.model.input_schema.masks
+            if mask.kind in trained.model.architecture.capabilities.supported_mask_kinds
+        )
+
+        for size in example_batch_sizes:
+            request = InterpretabilityRequest.create(
+                method=method,
+                model_id="a" * 64,
+                dataset_snapshot_id=built.plan.dataset.snapshot_id,
+                input_schema_hash=trained.model.input_schema.schema_hash,
+                split_role=data.split,
+                cohort=f"{data.split}-natural",
+                observation_uids=data.molecule_uids,
+                target=ExplanationTarget(
+                    output_name="activity_target_logit", class_id=1, class_name="active"
+                ),
+                baseline=None,
+                layer=None,
+                mask_policy=ExplanationMaskPolicy.create(
+                    mask_kinds=mask_kinds,
+                    handling=(
+                        "forward masks through the model and zero invalid input attributions"
+                    ),
+                ),
+                decision=ExplanationDecisionProvenance("fixed"),
+                parameters={"absolute": False, "example_batch_size": size},
+                random_seed=13,
+            )
+            gc.collect()
+            baseline_rss = int(process.memory_info().rss)
+            start = time.perf_counter()
+            result = explain_torch_model(trained.model, data, request)
+            elapsed = time.perf_counter() - start
+            peak = int(process.memory_info().rss) - baseline_rss
+            values = np.asarray(result.values)
+            results.append(
+                {
+                    "method": method,
+                    "example_batch_size": size,
+                    "n_rows_explained": int(values.shape[0]),
+                    "n_positions": n_positions,
+                    "seconds": elapsed,
+                    "rss_delta_bytes": max(0, peak),
+                    "attribution_checksum": float(np.abs(values).sum()),
+                }
+            )
+            del result, values
+            gc.collect()
+    return results

--- a/tests/acceptance/ml_scale_thresholds.json
+++ b/tests/acceptance/ml_scale_thresholds.json
@@ -1,0 +1,223 @@
+{
+  "schema_version": 1,
+  "work_package": "ML-700",
+  "source": "dev/in-progress/ml700_benchmark_plan.md",
+  "purpose": "Committed limits and regression thresholds for the ML data plane. ML-701 writes user-facing prose from this file; it is the machine-readable half of ML-700's published limits.",
+  "baseline_environment": {
+    "note": "Baselines were captured on a developer laptop. CI must compare ratios and structure, never absolute byte counts or wall times, because hardware differs.",
+    "platform": "macOS, Apple Silicon",
+    "python": "3.12.9",
+    "numpy": "1.26.4",
+    "sklearn": "1.9.0",
+    "torch": "2.13.0",
+    "total_memory_bytes": 137438953472
+  },
+  "estimator": {
+    "module": "smftools.machine_learning.data.partition_dataset",
+    "bytes_per_row": "2 * (n_positions * n_channels * 6 + n_channels + n_positions + 8 + (8 if labeled))",
+    "transient_multiplier": 2,
+    "materialization_multiplier": 3,
+    "default_materialization_budget_bytes": 2147483648,
+    "default_batch_budget_bytes": 67108864,
+    "default_batch_size": 64,
+    "verdict": "The 2x/3x constants were measured against cold-process peak RSS and hold. Worst-case measured slope was 12,950 bytes/row against 21,102 assumed, so the linear term is conservative by roughly 1.6x. No change is warranted; an over-conservative bound costs a config override, an under-conservative one costs a mid-run OOM."
+  },
+  "materialization_limits": {
+    "description": "Maximum rows in a single split that materialize() will approve at the default budget. Refusal fires when 3 * rows * bytes_per_row exceeds the budget. Rows are split rows, not experiment rows.",
+    "recomputable": "Every row here is derived from _bytes_per_row and the default budget. The unit test recomputes and compares, so changing an estimator constant fails immediately.",
+    "rows": [
+      {
+        "n_positions": 500,
+        "n_channels": 1,
+        "bytes_per_row": 7034,
+        "max_materializable_train_rows": 101766,
+        "max_rows_per_batch": 9540
+      },
+      {
+        "n_positions": 500,
+        "n_channels": 2,
+        "bytes_per_row": 13036,
+        "max_materializable_train_rows": 54911,
+        "max_rows_per_batch": 5147
+      },
+      {
+        "n_positions": 1000,
+        "n_channels": 1,
+        "bytes_per_row": 14034,
+        "max_materializable_train_rows": 51006,
+        "max_rows_per_batch": 4781
+      },
+      {
+        "n_positions": 1000,
+        "n_channels": 2,
+        "bytes_per_row": 26036,
+        "max_materializable_train_rows": 27493,
+        "max_rows_per_batch": 2577
+      },
+      {
+        "n_positions": 5000,
+        "n_channels": 1,
+        "bytes_per_row": 70034,
+        "max_materializable_train_rows": 10221,
+        "max_rows_per_batch": 958
+      },
+      {
+        "n_positions": 5000,
+        "n_channels": 2,
+        "bytes_per_row": 130036,
+        "max_materializable_train_rows": 5504,
+        "max_rows_per_batch": 516
+      },
+      {
+        "n_positions": 20000,
+        "n_channels": 1,
+        "bytes_per_row": 280034,
+        "max_materializable_train_rows": 2556,
+        "max_rows_per_batch": 239
+      },
+      {
+        "n_positions": 20000,
+        "n_channels": 2,
+        "bytes_per_row": 520036,
+        "max_materializable_train_rows": 1376,
+        "max_rows_per_batch": 129
+      }
+    ]
+  },
+  "workload_taxonomy": [
+    {
+      "workload": "partition batch read (iter_batches)",
+      "state": "supported",
+      "ceiling": "none",
+      "evidence": "Process RSS reaches a plateau independent of split size. Over 300 batches, per-batch growth decayed monotonically from 739,937 to 17,270 bytes, ending at 3.8% of one batch estimate.",
+      "guidance": "max_batch_bytes bounds one decoded batch, not process RSS. A process streaming a large split shows RSS far above the batch budget while remaining bounded; do not treat that as a leak."
+    },
+    {
+      "workload": "full split materialization (materialize)",
+      "state": "refused above the ceiling",
+      "ceiling": "see materialization_limits",
+      "evidence": "Refusal fires at preflight before allocation, exactly at the closed-form boundary.",
+      "guidance": "At production scale (roughly 10^6 reads) materialization is refused at every width. Use a streaming fit."
+    },
+    {
+      "workload": "sklearn training, incremental families",
+      "state": "supported",
+      "ceiling": "none",
+      "evidence": "fit_sklearn_partition_model_streaming plateaus at 132 MB over 300 batches with 1.02% final-quarter growth, and succeeds where the materialized path raises MLMemoryBudgetError.",
+      "guidance": "Only families declaring incremental_fit can stream. bernoulli_nb qualifies today."
+    },
+    {
+      "workload": "sklearn training, non-incremental families",
+      "state": "refused above the ceiling",
+      "ceiling": "see materialization_limits",
+      "evidence": "logistic_regression and random_forest have no partial_fit and require a materialized split.",
+      "guidance": "Refusal names the streaming-capable families. Raise max_materialization_bytes only if the split genuinely fits."
+    },
+    {
+      "workload": "Torch training",
+      "state": "supported, but memory is NOT modelled",
+      "ceiling": "unknown",
+      "evidence": "fit_torch_partition_model_streaming is bounded: it added 1,696.78 MB in its first decile then 0.00 and 0.25 MB in its last two. But the plateau reached 2,172 MB, which is 12,557x the data batch estimate.",
+      "guidance": "Process memory is dominated by model activations, which no budget in the ML data plane models. max_batch_bytes does not control Torch training memory, and the data budget cannot size a Torch job. Size empirically. Measured ratios across batch size and sequence length spanned 4,409x to 20,833x, so no fixed multiplier converts a data budget into a Torch prediction. See ML-205."
+    }
+  ],
+  "regression_thresholds": {
+    "materialization_worst_headroom_max": 1.0,
+    "materialization_headroom_soft_min": 0.25,
+    "streaming_tail_growth_fraction_max": 0.05,
+    "wall_time_regression_max_fraction": 0.5,
+    "notes": [
+      "Headroom is measured peak RSS divided by the analytic estimate, using the WORST observed peak across repeats, not the median. A memory bound is a worst-case claim.",
+      "Memory must be measured in a fresh process with no warmup. In-process RSS across repeats under-reports peak allocation once CPython's allocator holds a warm arena: 82 KB was measured for a 12 MB workload at two warmups.",
+      "Streaming workloads must never be thresholded on high-water RSS, which over-reports because freed pages are not returned to the OS. Use trajectory deceleration instead.",
+      "The bounded/accumulating verdict returned by measure_batch_trajectory is threshold-sensitive and has flipped between runs on identical behaviour. It is a reading aid, not a gate. Any CI use needs repeats and a wide margin."
+    ]
+  },
+  "unmodelled": [
+    {
+      "term": "Torch activation memory",
+      "owner": "ML-205",
+      "reason": "Dominates process RSS during Torch training by 3 to 4 orders of magnitude over the data estimate, with a non-constant ratio. No preflight covers it."
+    }
+  ],
+  "explanation_chunking": {
+    "method_measured": "Saliency",
+    "model": "residual_dilated_cnn",
+    "cohort": "400 rows x 400 positions x 1 channel",
+    "timing": [
+      {
+        "example_batch_size": 1,
+        "chunks": 400,
+        "seconds": 3.854,
+        "relative_to_best": 1.99
+      },
+      {
+        "example_batch_size": 8,
+        "chunks": 50,
+        "seconds": 1.933,
+        "relative_to_best": 1.0
+      },
+      {
+        "example_batch_size": 64,
+        "chunks": 7,
+        "seconds": 4.962,
+        "relative_to_best": 2.57
+      },
+      {
+        "example_batch_size": 512,
+        "chunks": 1,
+        "seconds": 5.334,
+        "relative_to_best": 2.76
+      }
+    ],
+    "guidance": [
+      "Wall time has an interior optimum. Larger chunks are not faster: the largest chunk measured was 2.76x slower than the best, and the smallest was 1.99x slower. Do not assume 'batch it all at once' is the fast path.",
+      "example_batch_size is a SCIENTIFIC parameter, not only a performance knob. Changing it changes attribution values by roughly 1.1e-3 relative (max absolute difference 2.27e-4 against a max value of 0.204), deterministically -- attributions repeat bitwise at a fixed chunk size but differ across chunk sizes, consistent with batch-size-dependent convolution kernel selection accumulating through the residual blocks.",
+      "Choose a chunk size and hold it fixed across runs you intend to compare. Tuning it for speed between runs silently perturbs the attributions being compared.",
+      "Provenance is intact: example_batch_size is part of request.parameters and therefore request_id, and result_id incorporates request_id. Two explanations computed at different chunk sizes are correctly recorded as different results rather than colliding."
+    ],
+    "caveats": [
+      "Timing measured in-process on one laptop; treat the shape of the curve as the finding, not the absolute seconds.",
+      "Memory across chunk sizes was NOT measured reliably. The sweep runs chunk sizes sequentially in one process, so a warm allocator arena under-reports later cells -- one cell reported 0.1 MB for work comparable to a cell reporting 46.8 MB. Measuring explanation memory needs the cold-subprocess discipline used for reads."
+    ]
+  },
+  "worker_scaling": {
+    "cohort": "3000 train rows x 1000 positions x 1 channel",
+    "measurement": "Shard 0 only, read sequentially in-process at each num_workers. This measures the cost of the sharding arithmetic, NOT parallel wall-clock speedup.",
+    "shards": [
+      {
+        "num_workers": 1,
+        "shard_rows": 3000,
+        "median_seconds": 5.469,
+        "rows_per_second": 549,
+        "efficiency_vs_ideal": 1.0
+      },
+      {
+        "num_workers": 2,
+        "shard_rows": 1500,
+        "median_seconds": 2.657,
+        "rows_per_second": 565,
+        "efficiency_vs_ideal": 1.03
+      },
+      {
+        "num_workers": 4,
+        "shard_rows": 750,
+        "median_seconds": 1.324,
+        "rows_per_second": 566,
+        "efficiency_vs_ideal": 1.03
+      },
+      {
+        "num_workers": 8,
+        "shard_rows": 375,
+        "median_seconds": 0.661,
+        "rows_per_second": 567,
+        "efficiency_vs_ideal": 1.03
+      }
+    ],
+    "guidance": [
+      "Sharding is free. Per-shard throughput is flat at roughly 550-570 rows/second regardless of worker count, and shard time scales as 1/N with no measurable per-shard overhead. Splitting a read across workers costs nothing in arithmetic terms.",
+      "This does NOT establish an N-times wall-clock speedup. Shards were read one at a time in a single process; real parallel workers contend for disk and memory bandwidth, and that contention is unmeasured here.",
+      "Shard disjointness and determinism are contracts covered separately by tests/integration/machine_learning/test_partition_dataset.py, not by this timing sweep."
+    ]
+  }
+}

--- a/tests/integration/machine_learning/test_ml_scale_qualification.py
+++ b/tests/integration/machine_learning/test_ml_scale_qualification.py
@@ -1,0 +1,102 @@
+"""Measured scale qualification for the ML data plane (ML-700).
+
+Runs under the ``integration`` marker, which `ci.yml` does not invoke on pull
+requests — it executes weekly via `extended-ci.yml`. The fast, fixture-free
+arithmetic guard that *does* run per PR lives in
+``tests/unit/machine_learning/test_ml_scale_thresholds.py``; this file covers
+what only measurement can establish.
+
+Cells are deliberately small. The published limits come from an operator-invoked
+sweep on real hardware (see ``dev/in-progress/ml700_benchmark_plan.md``); what is
+asserted here is *behaviour that must not regress* — refusal firing at the
+closed-form boundary, refusal happening before allocation, and streaming reads
+staying bounded — never absolute byte counts, which are hardware-specific.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from smftools.machine_learning.benchmarks.fixtures import FixtureSpec, build_fixture
+from smftools.machine_learning.benchmarks.sweeps import sweep_refusal_boundary
+from smftools.machine_learning.data.partition_dataset import (
+    MLMemoryBudgetError,
+    PartitionReadPolicy,
+)
+
+pytestmark = pytest.mark.integration
+
+THRESHOLDS = json.loads(
+    Path("tests/acceptance/ml_scale_thresholds.json").read_text(encoding="utf-8")
+)
+
+
+def test_refusal_fires_exactly_at_the_closed_form_boundary(tmp_path: Path) -> None:
+    # Probes budgets at estimate, estimate+1, and estimate-1, so the boundary is
+    # pinned to the formula rather than to a remembered row count.
+    results = sweep_refusal_boundary(n_rows=60, n_positions=200, root=tmp_path)
+
+    by_name = {result.cell.name.split("_")[0]: result for result in results}
+    assert by_name["at"].state == "supported"
+    assert by_name["above"].state == "supported"
+    assert by_name["below"].state == "refused"
+
+
+def test_refusal_happens_before_allocation_and_names_a_remedy(tmp_path: Path) -> None:
+    spec = FixtureSpec(n_rows=60, n_positions=200, n_channels=1)
+    probe = build_fixture(tmp_path / "probe", spec)
+    estimate = probe.plan.estimate_materialization_bytes("train")
+    built = build_fixture(
+        tmp_path / "tight",
+        spec,
+        policy=PartitionReadPolicy(max_materialization_bytes=estimate - 1),
+    )
+
+    with pytest.raises(MLMemoryBudgetError) as error:
+        built.dataset.materialize("train")
+
+    message = str(error.value)
+    assert str(estimate) in message.replace(",", "")
+    assert "iter_batches" in message
+
+
+def test_streaming_reads_stay_bounded_as_the_split_grows(tmp_path: Path) -> None:
+    # The bounded-memory acceptance criterion. Asserted as a *shape* claim --
+    # batch count rises 4x while the per-batch estimate is unchanged -- rather
+    # than as a byte threshold, because high-water RSS over-reports for
+    # streaming workloads and is meaningless as a bound.
+    batch_counts = []
+    for index, n_rows in enumerate((200, 800)):
+        built = build_fixture(
+            tmp_path / f"rows-{index}",
+            FixtureSpec(n_rows=n_rows, n_positions=200, n_channels=1),
+            policy=PartitionReadPolicy(batch_size=16),
+        )
+        estimate = built.plan.estimate_batch_bytes(built.plan.effective_batch_size)
+        observed = 0
+        for batch in built.dataset.iter_batches("train"):
+            assert built.plan.estimate_batch_bytes(len(batch.molecule_uids)) <= estimate
+            observed += 1
+        batch_counts.append(observed)
+
+    assert batch_counts[1] > batch_counts[0], "the larger split must decode more batches"
+
+
+def test_committed_limits_still_describe_the_live_defaults(tmp_path: Path) -> None:
+    # Bridges the committed table to a real store: a fixture built at a shape
+    # listed in the limits must report the published bytes_per_row.
+    published = {
+        (row["n_positions"], row["n_channels"]): row
+        for row in THRESHOLDS["materialization_limits"]["rows"]
+    }
+    row = published[(500, 1)]
+    built = build_fixture(tmp_path, FixtureSpec(n_rows=60, n_positions=500, n_channels=1))
+
+    assert built.plan.bytes_per_row == row["bytes_per_row"]
+    assert (
+        built.plan.policy.max_materialization_bytes
+        == THRESHOLDS["estimator"]["default_materialization_budget_bytes"]
+    )

--- a/tests/unit/machine_learning/test_ml_scale_thresholds.py
+++ b/tests/unit/machine_learning/test_ml_scale_thresholds.py
@@ -1,0 +1,175 @@
+"""Per-PR guard for the committed ML scale limits (ML-700).
+
+Deliberately fast and fixture-free: it recomputes every published limit from the
+estimator itself and compares. Changing ``_bytes_per_row`` or a default budget
+moves refusal boundaries package-wide, and this fails immediately rather than
+waiting for the weekly measured suite in
+``tests/integration/machine_learning/test_ml_scale_qualification.py``.
+
+It asserts arithmetic and structure only. Nothing here measures memory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from smftools.machine_learning.data.partition_dataset import (
+    DEFAULT_BATCH_MEMORY_BYTES,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_MATERIALIZATION_MEMORY_BYTES,
+    _bytes_per_row,
+)
+
+THRESHOLDS_PATH = Path("tests/acceptance/ml_scale_thresholds.json")
+
+VALID_STATES = {
+    "supported",
+    "refused above the ceiling",
+    "supported, but memory is NOT modelled",
+}
+
+
+@pytest.fixture(scope="module")
+def thresholds() -> dict:
+    return json.loads(THRESHOLDS_PATH.read_text(encoding="utf-8"))
+
+
+def test_thresholds_file_declares_its_schema(thresholds: dict) -> None:
+    assert thresholds["schema_version"] == 1
+    assert thresholds["work_package"] == "ML-700"
+    assert thresholds["source"]
+
+
+def test_published_estimator_constants_match_the_implementation(thresholds: dict) -> None:
+    estimator = thresholds["estimator"]
+
+    assert estimator["transient_multiplier"] == 2
+    assert estimator["materialization_multiplier"] == 3
+    assert estimator["default_materialization_budget_bytes"] == DEFAULT_MATERIALIZATION_MEMORY_BYTES
+    assert estimator["default_batch_budget_bytes"] == DEFAULT_BATCH_MEMORY_BYTES
+    assert estimator["default_batch_size"] == DEFAULT_BATCH_SIZE
+
+
+def test_every_published_limit_recomputes_from_the_estimator(thresholds: dict) -> None:
+    # The published ceilings are not transcribed numbers to be trusted; they are
+    # derivable, and this is the derivation. A changed estimator constant fails
+    # here on the pull request that changes it.
+    budget = DEFAULT_MATERIALIZATION_MEMORY_BYTES
+    rows = thresholds["materialization_limits"]["rows"]
+    assert rows, "published limits must not be empty"
+
+    for row in rows:
+        expected_bytes_per_row = _bytes_per_row(row["n_positions"], row["n_channels"], labeled=True)
+        assert row["bytes_per_row"] == expected_bytes_per_row, (
+            f"bytes_per_row for {row['n_positions']}x{row['n_channels']} is stale; "
+            "the estimator changed and the published limits were not regenerated"
+        )
+        assert row["max_materializable_train_rows"] == budget // (3 * expected_bytes_per_row)
+        assert row["max_rows_per_batch"] == DEFAULT_BATCH_MEMORY_BYTES // expected_bytes_per_row
+
+
+def test_published_limits_cover_both_modality_shapes(thresholds: dict) -> None:
+    channels = {row["n_channels"] for row in thresholds["materialization_limits"]["rows"]}
+
+    assert channels == {1, 2}, "limits must cover deaminase (1) and conversion (2) shapes"
+
+
+def test_taxonomy_assigns_every_workload_a_recognised_state(thresholds: dict) -> None:
+    taxonomy = thresholds["workload_taxonomy"]
+    assert taxonomy
+
+    for entry in taxonomy:
+        assert entry["state"] in VALID_STATES, entry["state"]
+        assert entry["evidence"].strip()
+        assert entry["guidance"].strip()
+
+
+def test_taxonomy_covers_both_training_backends_and_both_read_modes(thresholds: dict) -> None:
+    workloads = " ".join(entry["workload"] for entry in thresholds["workload_taxonomy"])
+
+    assert "iter_batches" in workloads
+    assert "materialize" in workloads
+    assert "sklearn" in workloads
+    assert "Torch" in workloads
+
+
+def test_torch_memory_is_declared_unmodelled_rather_than_silently_omitted(
+    thresholds: dict,
+) -> None:
+    # Torch process memory is dominated by activations, which no budget models.
+    # A limits document that quietly omitted the dominant term would be worse
+    # than one naming it, so the omission is asserted to stay explicit and
+    # attributed to a work package.
+    torch_entry = next(
+        entry for entry in thresholds["workload_taxonomy"] if "Torch" in entry["workload"]
+    )
+    assert torch_entry["state"] == "supported, but memory is NOT modelled"
+    assert torch_entry["ceiling"] == "unknown"
+
+    unmodelled = thresholds["unmodelled"]
+    assert unmodelled, "the unmodelled register must not be empty while Torch is unmodelled"
+    owners = {item["owner"] for item in unmodelled}
+    assert "ML-205" in owners
+
+
+def test_regression_thresholds_are_ordered_and_documented(thresholds: dict) -> None:
+    limits = thresholds["regression_thresholds"]
+
+    assert limits["materialization_worst_headroom_max"] == 1.0
+    assert 0 < limits["materialization_headroom_soft_min"] < 1.0
+    assert 0 < limits["streaming_tail_growth_fraction_max"] < 1.0
+    assert limits["wall_time_regression_max_fraction"] > 0
+    # The notes carry the measurement caveats. Without them a future reader
+    # would reasonably threshold streaming on high-water RSS, which this
+    # package established is meaningless as a bound.
+    assert len(limits["notes"]) >= 4
+
+
+def test_baselines_are_marked_hardware_specific(thresholds: dict) -> None:
+    note = thresholds["baseline_environment"]["note"]
+
+    assert "ratio" in note.lower()
+
+
+def test_explanation_chunking_guidance_is_published_with_its_caveats(thresholds: dict) -> None:
+    # example_batch_size reads like a performance knob but changes attribution
+    # values by roughly 1e-3 relative. The guidance has to say so, or a user
+    # tuning it for speed silently perturbs the results being compared.
+    chunking = thresholds["explanation_chunking"]
+
+    assert chunking["timing"], "chunk-size timing must be published"
+    assert any(entry["relative_to_best"] == 1.0 for entry in chunking["timing"]), (
+        "the timing table must identify which chunk size was fastest"
+    )
+    largest = max(chunking["timing"], key=lambda entry: entry["example_batch_size"])
+    assert largest["relative_to_best"] > 1.0, (
+        "the largest chunk must not be recorded as fastest; the measured optimum is interior "
+        "and the guidance depends on that"
+    )
+    guidance = " ".join(chunking["guidance"]).lower()
+    assert "scientific parameter" in guidance
+    assert "hold it fixed" in guidance
+    # Memory across chunk sizes was not measured reliably; the caveat must stay
+    # visible so nobody quotes the sequential in-process numbers as limits.
+    assert any("memory" in caveat.lower() for caveat in chunking["caveats"])
+
+
+def test_worker_scaling_guidance_separates_sharding_cost_from_wall_clock(thresholds: dict) -> None:
+    # Sharding being free is a claim about arithmetic overhead, not about
+    # parallel speedup. The distinction has to survive in the published text,
+    # or "sharding is free" will be read as "N workers are N times faster".
+    scaling = thresholds["worker_scaling"]
+    shards = scaling["shards"]
+
+    assert [entry["num_workers"] for entry in shards] == [1, 2, 4, 8]
+    total = shards[0]["shard_rows"]
+    for entry in shards:
+        assert entry["shard_rows"] * entry["num_workers"] == total, (
+            "shards must partition the split exactly"
+        )
+    guidance = " ".join(scaling["guidance"]).lower()
+    assert "does not establish" in guidance
+    assert "contend" in guidance


### PR DESCRIPTION
Completes ML-700's measurement work. The limits ship as a machine-readable file rather than prose: the ledger's file-ownership table assigns documentation to ML-701, which will write the user-facing page from this.

tests/acceptance/ml_scale_thresholds.json carries the ceiling table, a workload taxonomy, regression thresholds, explanation-chunking and worker-scaling guidance, and a register of terms that are measured but deliberately not modelled. It sits under tests/acceptance/ alongside partitioned_pipeline_criteria.json because it is a test expectation, not shipped runtime data.

Two test tiers, because -m integration does not run on pull requests -- it runs weekly via extended-ci.yml:

- tests/unit/machine_learning/test_ml_scale_thresholds.py runs per PR. It is fixture-free and recomputes every published ceiling from _bytes_per_row rather than trusting transcribed numbers, so changing an estimator constant fails on the pull request that changes it.
- tests/integration/machine_learning/test_ml_scale_qualification.py runs weekly and asserts behaviour that must not regress -- refusal at the closed-form boundary, refusal before allocation, streaming staying bounded -- never absolute byte counts, which are hardware-specific.

Findings behind the published numbers
-------------------------------------
Estimator: the 2x/3x constants hold. Worst-case measured slope was 12,950 bytes/row against 21,102 assumed, conservative by roughly 1.6x. No change warranted -- an over-conservative bound costs a config override, an under-conservative one costs a mid-run OOM.

Worker scaling (Sweep C): sharding is free. Per-shard throughput is flat at 549-567 rows/second across 1, 2, 4, and 8 workers, and shard time scales as 1/N with no measurable overhead. This does not establish an N-times wall-clock speedup: shards were read one at a time in one process, so bandwidth contention between real parallel workers is unmeasured. The per-PR guard asserts that disclaimer survives in the published text.

Explanation chunking (Sweep D): wall time has an interior optimum -- example_batch_size=8 was fastest, with 1 at 1.99x and 512 at 2.76x, so larger chunks are not faster. More importantly example_batch_size is a scientific parameter, not only a performance knob: attributions repeat bitwise at a fixed chunk size but differ by ~1.1e-3 relative across chunk sizes, consistent with batch-size-dependent convolution kernel selection. Provenance is intact -- example_batch_size is already part of request.parameters and therefore request_id -- so differing chunk sizes are recorded as different results rather than colliding. Guidance: pick a chunk size and hold it across runs intended for comparison.

Torch training memory is recorded as measured but NOT modelled, with ML-205 named as owner. Process RSS reached 12,557x the data batch estimate because activations dominate, and the ratio is not constant -- it spanned 4,409x to 20,833x across batch size and sequence length -- so no multiplier converts a data budget into a Torch prediction. A limits document that quietly omitted the dominant memory term would be worse than one naming it, so a test asserts the omission stays explicit and attributed.

Known gaps, recorded rather than omitted: no CUDA device on the measuring host, so the device axis covers cpu and mps only; and explanation memory across chunk sizes is unmeasured, because the sweep runs chunk sizes sequentially in one process and a warm allocator arena under-reports later cells.

Validation: Ruff check and format clean; git diff --check clean; per-PR selection (-m "smoke or unit") 1648 passed, 9 skipped, 7 xfailed; weekly selection (-m integration) 38 passed, 2 skipped.