### PR TITLE
Wire streaming training into the orchestration facade

### DIFF
--- a/src/smftools/machine_learning/orchestration/actions.py
+++ b/src/smftools/machine_learning/orchestration/actions.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from ..data.materialized_dataset import MLDatasetProtocol
 from ..data.partition_dataset import (
     MLMaterializedPartitionData,
+    MLMemoryBudgetError,
     MLPartitionBatch,
 )
 from ..data.transforms import FeatureTransformSpec
@@ -35,7 +36,9 @@ from ..training import (
     TorchTrainingConfig,
     TorchTrainingResult,
     fit_sklearn_partition_model,
+    fit_sklearn_partition_model_streaming,
     fit_torch_partition_model,
+    fit_torch_partition_model_streaming,
 )
 from .contracts import MLJobServiceError
 
@@ -45,21 +48,61 @@ _Data = MLMaterializedPartitionData | MLPartitionBatch
 
 @dataclass(frozen=True)
 class SklearnTrainOptions:
-    """Explicit sklearn-only options for backend-neutral training dispatch."""
+    """Explicit sklearn-only options for backend-neutral training dispatch.
+
+    Fields:
+        streaming: Whether to fit from streamed batches instead of a
+            materialized split. ``None`` streams whenever the family declares
+            ``incremental_fit``, because a streamed sklearn fit is
+            *numerically identical* to the materialized one -- same
+            ``feature_log_prob_``, same predictions, same balance and transform
+            identities. There is no reason to make the user ask for it. ``True``
+            demands streaming and raises for a family without ``partial_fit``;
+            ``False`` forces the materialized path and its memory ceiling.
+    """
 
     transform_spec: FeatureTransformSpec | None = None
     balancing: BalancingSpec | None = None
     seed: int = 0
     incremental: bool | None = None
+    streaming: bool | None = None
 
 
 @dataclass(frozen=True)
 class TorchTrainOptions:
-    """Explicit plain-Torch-only options for backend-neutral training dispatch."""
+    """Explicit plain-Torch-only options for backend-neutral training dispatch.
+
+    Fields:
+        streaming: Whether to train from streamed batches. Defaults to
+            ``False``, unlike the sklearn option, and the asymmetry is
+            deliberate: a streamed Torch fit shuffles within a buffer rather
+            than globally, so it produces **different weights** from a
+            materialized fit at the same seed. Switching strategy silently
+            would change a user's model without them asking. Opting in is one
+            argument, and the materialization refusal names it.
+    """
 
     training_config: TorchTrainingConfig | None = None
     transform_spec: FeatureTransformSpec | None = None
     balancing: BalancingSpec | None = None
+    streaming: bool = False
+
+
+def _materialized_or_guided(operation, *, remedy: str):
+    """Run a materializing fit, naming the streaming remedy if it is refused.
+
+    ``MLMemoryBudgetError`` reports the estimate and the budget, which is the
+    right message for a bare read. At the training boundary the caller also
+    needs to know a streaming engine exists, so the refusal is re-raised with
+    that named. The original is preserved as the cause.
+    """
+    try:
+        return operation()
+    except MLMemoryBudgetError as exc:
+        raise MLJobServiceError(
+            f"training refused: the train split exceeds max_materialization_bytes ({exc}). "
+            f"Retry with {remedy}."
+        ) from exc
 
 
 def train_partition_model(
@@ -70,31 +113,84 @@ def train_partition_model(
     torch_options: TorchTrainOptions | None = None,
     registry: ModelRegistry = BUILTIN_MODEL_REGISTRY,
 ) -> SklearnTrainingResult | TorchTrainingResult:
-    """Train one resolved model through its canonical backend engine."""
+    """Train one resolved model through its canonical backend engine.
+
+    Dispatches to a streaming or materializing engine per backend. See
+    :class:`SklearnTrainOptions` and :class:`TorchTrainOptions` for why the
+    defaults differ: a streamed sklearn fit reproduces the materialized one
+    exactly, while a streamed Torch fit does not.
+    """
     if resolved_model.backend == "sklearn":
         if torch_options is not None:
             raise MLJobServiceError("Torch options cannot be supplied to an sklearn model")
         options = sklearn_options or SklearnTrainOptions()
-        return fit_sklearn_partition_model(
-            dataset,
-            resolved_model,
-            transform_spec=options.transform_spec,
-            balancing=options.balancing,
-            seed=options.seed,
-            incremental=options.incremental,
-            registry=registry,
+        incremental_capable = bool(resolved_model.capabilities.incremental_fit)
+        use_streaming = incremental_capable if options.streaming is None else options.streaming
+        if use_streaming and not incremental_capable:
+            raise MLJobServiceError(
+                f"model family {resolved_model.family!r} cannot stream: it has no partial_fit. "
+                "Use SklearnTrainOptions(streaming=False) to materialize the train split, which "
+                "is bounded by max_materialization_bytes."
+            )
+        if use_streaming:
+            if options.incremental is False:
+                raise MLJobServiceError(
+                    "streaming=True and incremental=False are contradictory; a streamed sklearn "
+                    "fit is always incremental"
+                )
+            return fit_sklearn_partition_model_streaming(
+                dataset,
+                resolved_model,
+                transform_spec=options.transform_spec,
+                balancing=options.balancing,
+                seed=options.seed,
+                registry=registry,
+            )
+        return _materialized_or_guided(
+            lambda: fit_sklearn_partition_model(
+                dataset,
+                resolved_model,
+                transform_spec=options.transform_spec,
+                balancing=options.balancing,
+                seed=options.seed,
+                incremental=options.incremental,
+                registry=registry,
+            ),
+            remedy=(
+                "SklearnTrainOptions(streaming=True)"
+                if incremental_capable
+                else (
+                    f"a streaming-capable family (model family {resolved_model.family!r} has no "
+                    "partial_fit), or raise max_materialization_bytes if the split genuinely fits"
+                )
+            ),
         )
     if resolved_model.backend == "torch":
         if sklearn_options is not None:
             raise MLJobServiceError("sklearn options cannot be supplied to a Torch model")
         options = torch_options or TorchTrainOptions()
-        return fit_torch_partition_model(
-            dataset,
-            resolved_model,
-            training_config=options.training_config,
-            transform_spec=options.transform_spec,
-            balancing=options.balancing,
-            registry=registry,
+        if options.streaming:
+            return fit_torch_partition_model_streaming(
+                dataset,
+                resolved_model,
+                training_config=options.training_config,
+                transform_spec=options.transform_spec,
+                balancing=options.balancing,
+                registry=registry,
+            )
+        return _materialized_or_guided(
+            lambda: fit_torch_partition_model(
+                dataset,
+                resolved_model,
+                training_config=options.training_config,
+                transform_spec=options.transform_spec,
+                balancing=options.balancing,
+                registry=registry,
+            ),
+            remedy=(
+                "TorchTrainOptions(streaming=True), noting that a streamed fit shuffles within a "
+                "buffer rather than globally and therefore produces different weights"
+            ),
         )
     raise MLJobServiceError(f"unsupported training backend {resolved_model.backend!r}")
 

--- a/src/smftools/machine_learning/training/__init__.py
+++ b/src/smftools/machine_learning/training/__init__.py
@@ -8,6 +8,7 @@ from .sklearn_backend import (
     SklearnTrainingError,
     SklearnTrainingResult,
     fit_sklearn_partition_model,
+    fit_sklearn_partition_model_streaming,
 )
 from .torch_backend import (
     TORCH_TRAINING_CONFIG_VERSION,
@@ -18,6 +19,7 @@ from .torch_backend import (
     TorchTrainingError,
     TorchTrainingResult,
     fit_torch_partition_model,
+    fit_torch_partition_model_streaming,
 )
 
 if TYPE_CHECKING:
@@ -64,7 +66,9 @@ __all__ = [
     "TorchTrainingError",
     "TorchTrainingResult",
     "fit_sklearn_partition_model",
+    "fit_sklearn_partition_model_streaming",
     "fit_torch_partition_model",
+    "fit_torch_partition_model_streaming",
     "run_sliding_window_lightning_training",
     "run_sliding_window_sklearn_training",
     "train_lightning_model",

--- a/tests/integration/machine_learning/test_ml_training_dispatch.py
+++ b/tests/integration/machine_learning/test_ml_training_dispatch.py
@@ -1,0 +1,174 @@
+"""Streaming reaches the orchestration façade (ML-204 follow-up).
+
+ML-204 added streaming fit engines but left ``train_partition_model`` calling
+the materializing ones, so a user on the approved orchestration surface still
+hit the memory ceiling the package existed to remove. These tests pin the
+dispatch behaviour and the deliberately asymmetric defaults.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from smftools.machine_learning.benchmarks.fixtures import FixtureSpec, build_fixture
+from smftools.machine_learning.data.partition_dataset import PartitionReadPolicy
+from smftools.machine_learning.models.registry import BUILTIN_MODEL_REGISTRY
+from smftools.machine_learning.orchestration import (
+    MLJobServiceError,
+    SklearnTrainOptions,
+    TorchTrainOptions,
+    train_partition_model,
+)
+from smftools.machine_learning.training.torch_backend import TorchTrainingConfig
+
+pytestmark = pytest.mark.integration
+
+SPEC = FixtureSpec(n_rows=120, n_positions=16, n_channels=1, imbalanced=True)
+
+
+def _roomy(tmp_path: Path):
+    return build_fixture(tmp_path, SPEC)
+
+
+def _tight(tmp_path: Path):
+    """A dataset whose train split is one byte over the materialization budget."""
+    probe = build_fixture(tmp_path / "probe", SPEC)
+    estimate = probe.plan.estimate_materialization_bytes("train")
+    return build_fixture(
+        tmp_path / "tight",
+        SPEC,
+        policy=PartitionReadPolicy(max_materialization_bytes=estimate - 1),
+    )
+
+
+def _resolved(built, family: str):
+    parameters = {"n_estimators": 3} if family == "random_forest" else None
+    return BUILTIN_MODEL_REGISTRY.resolve(
+        family, input_schema=built.plan.dataset.input_schema, parameters=parameters
+    )
+
+
+def test_incremental_sklearn_family_streams_by_default(tmp_path: Path) -> None:
+    # The point of the fix: the approved entry point now works above the
+    # materialization ceiling without the caller asking for anything.
+    built = _tight(tmp_path)
+
+    result = train_partition_model(built.dataset, _resolved(built, "bernoulli_nb"))
+
+    assert result.model.fit_mode == "partial_fit"
+    assert result.n_training_observations == len(built.plan.entries_for("train"))
+
+
+def test_default_streaming_reproduces_the_materialized_sklearn_fit(tmp_path: Path) -> None:
+    # The default only flipped because streamed and materialized sklearn fits
+    # are the same model. If that ever stops being true, the default is wrong.
+    built = _roomy(tmp_path)
+    resolved = _resolved(built, "bernoulli_nb")
+
+    streamed = train_partition_model(built.dataset, resolved)
+    materialized = train_partition_model(
+        built.dataset, resolved, sklearn_options=SklearnTrainOptions(streaming=False)
+    )
+
+    np.testing.assert_allclose(
+        streamed.model.estimator.feature_log_prob_,
+        materialized.model.estimator.feature_log_prob_,
+    )
+    assert streamed.balance.resolution_id == materialized.balance.resolution_id
+    assert streamed.model.transform.transform_id == materialized.model.transform.transform_id
+
+
+def test_forcing_materialization_still_hits_the_ceiling_with_a_named_remedy(
+    tmp_path: Path,
+) -> None:
+    built = _tight(tmp_path)
+
+    with pytest.raises(MLJobServiceError) as error:
+        train_partition_model(
+            built.dataset,
+            _resolved(built, "bernoulli_nb"),
+            sklearn_options=SklearnTrainOptions(streaming=False),
+        )
+
+    message = str(error.value)
+    assert "max_materialization_bytes" in message
+    assert "SklearnTrainOptions(streaming=True)" in message
+
+
+def test_non_incremental_family_cannot_stream_and_says_why(tmp_path: Path) -> None:
+    built = _roomy(tmp_path)
+
+    with pytest.raises(MLJobServiceError) as error:
+        train_partition_model(
+            built.dataset,
+            _resolved(built, "random_forest"),
+            sklearn_options=SklearnTrainOptions(streaming=True),
+        )
+
+    message = str(error.value)
+    assert "random_forest" in message
+    assert "partial_fit" in message
+
+
+def test_non_incremental_family_refusal_names_a_streaming_capable_family(
+    tmp_path: Path,
+) -> None:
+    built = _tight(tmp_path)
+
+    with pytest.raises(MLJobServiceError) as error:
+        train_partition_model(built.dataset, _resolved(built, "random_forest"))
+
+    message = str(error.value)
+    assert "streaming-capable family" in message
+    assert "max_materialization_bytes" in message
+
+
+def test_contradictory_streaming_and_incremental_options_are_rejected(tmp_path: Path) -> None:
+    built = _roomy(tmp_path)
+
+    with pytest.raises(MLJobServiceError, match="contradictory"):
+        train_partition_model(
+            built.dataset,
+            _resolved(built, "bernoulli_nb"),
+            sklearn_options=SklearnTrainOptions(streaming=True, incremental=False),
+        )
+
+
+def test_torch_does_not_stream_by_default_because_weights_would_change(
+    tmp_path: Path,
+) -> None:
+    # Asymmetry with sklearn is deliberate: a streamed Torch fit shuffles within
+    # a buffer, so switching silently would hand the user a different model.
+    built = _tight(tmp_path)
+
+    with pytest.raises(MLJobServiceError) as error:
+        train_partition_model(
+            built.dataset,
+            _resolved(built, "residual_dilated_cnn"),
+            torch_options=TorchTrainOptions(
+                training_config=TorchTrainingConfig(max_epochs=1, device="cpu", batch_size=16)
+            ),
+        )
+
+    message = str(error.value)
+    assert "TorchTrainOptions(streaming=True)" in message
+    assert "different weights" in message
+
+
+def test_torch_streams_when_asked(tmp_path: Path) -> None:
+    built = _tight(tmp_path)
+
+    result = train_partition_model(
+        built.dataset,
+        _resolved(built, "residual_dilated_cnn"),
+        torch_options=TorchTrainOptions(
+            streaming=True,
+            training_config=TorchTrainingConfig(max_epochs=2, device="cpu", batch_size=16),
+        ),
+    )
+
+    assert len(result.model.history) == 2
+    assert np.isfinite(result.model.test_loss)


### PR DESCRIPTION
ML-204 shipped streaming fit engines but never connected them. Found while writing ML-701's quick starts: train_partition_model called only the materializing fits, the streaming ones were not exported from training/__init__.py, and their only callers anywhere in the package were the benchmark modules. A user on the approved orchestration surface still hit the ~85,000-row materialization ceiling that ML-204 existed to remove.

Exports both streaming fits and adds a streaming option to SklearnTrainOptions and TorchTrainOptions.

The defaults are deliberately asymmetric, and the asymmetry is grounded in measurement rather than taste:

- sklearn defaults to streaming whenever the family declares incremental_fit, because a streamed sklearn fit is numerically identical to the materialized one -- same feature_log_prob_, same class_log_prior_, same predictions, same balance and transform identities. There is no reason to make a user ask for a result they would get anyway.
- Torch defaults to materializing, because a streamed Torch fit shuffles within a buffer rather than globally and therefore produces different weights at the same seed. Flipping that default silently would hand someone a different model without them asking for one. Opting in is a single argument.

A test pins the sklearn default to its justification: it asserts streamed and materialized fits still agree. If that ever stops being true the default is wrong, and the test says so rather than the behaviour drifting quietly.

Materialization refusals at the training boundary are re-raised naming the remedy -- SklearnTrainOptions(streaming=True), TorchTrainOptions(streaming=True) with a note that weights will differ, or a streaming-capable family for estimators with no partial_fit. MLMemoryBudgetError reports the estimate and budget, which is right for a bare read; at the training boundary the caller also needs to know a streaming engine exists. The original is preserved as __cause__.

Validation: Ruff check and format clean; git diff --check clean; 8 new dispatch tests; per-PR selection 1648 passed, 9 skipped, 7 xfailed; integration 46 passed, 2 skipped.