### PR TITLE
Add ML guidance pages for splits, interpretability, and artifacts

### DIFF
--- a/docs/source/ml/artifacts_and_trust.md
+++ b/docs/source/ml/artifacts_and_trust.md
@@ -1,0 +1,82 @@
+# Artifacts, provenance, and trust
+
+Fitted models are published as immutable, content-addressed artifacts. This page covers what gets
+written, what makes a result traceable, and where the security boundary sits when loading a model
+someone else produced.
+
+## Publication is transactional
+
+A run builds into a unique staging location, is validated, and is then published atomically. A
+failure leaves the previous state intact rather than a half-written directory that looks complete.
+
+Every published artifact carries a checksum inventory, so a truncated or altered payload is
+detected on load rather than silently used.
+
+## What makes a model traceable
+
+A fitted model records the identities of everything that produced it:
+
+| Field | Answers |
+| --- | --- |
+| `dataset_snapshot_id` | Which rows, which channels, which label schema |
+| `split_id` | Which group-disjoint membership |
+| `transform.transform_id` | Which fitted preprocessing, from train rows only |
+| `balance.resolution_id` | Which rows were selected, with which weights and seed |
+| `training_config` (Torch) | Optimizer, early stopping, seed, device, shuffle buffer |
+
+These are content-addressed. Two runs over the same rows with the same declarations produce the
+same identities. Anything that genuinely changes the result changes them.
+
+The converse matters as much: identities are computed from **declared content**, never from
+execution strategy. Batch size, worker count, and streaming-versus-materialised do not change a
+transform's identity, because they do not change the transform. Where a knob genuinely does change
+results it is part of the declared config — `shuffle_buffer_batches` for streamed Torch training,
+`example_batch_size` for attributions — so the identity reflects it rather than hiding it.
+
+:::{note}
+`transform_id` hashes the fitted statistics at fixed precision rather than raw float64. Without
+that, summation order leaks in and `batch_size` — a pure performance knob — changes a transform's
+identity and therefore the lineage of every model fitted with it.
+:::
+
+## Loading a model is a trust decision
+
+Deserialising a model executes code. The package treats that as a security boundary rather than an
+implementation detail, and the two backends handle it differently.
+
+**sklearn artifacts use `skops`, not pickle.** On save, every type `skops` considers untrusted is
+inspected, and anything outside the reviewed set is refused rather than written. On load, the same
+check runs again, so a payload containing an unapproved type raises instead of executing.
+
+**Torch artifacts load with `weights_only=True`.** The checkpoint carries tensors, not arbitrary
+objects, so loading cannot execute code embedded in the file.
+
+What this does and does not buy you:
+
+- It protects against a model file that has been tampered with or crafted to execute code on load.
+- It does **not** tell you whether a model is scientifically sound, or trained on the data its
+  manifest claims. Provenance identities let you check that a model matches a dataset you trust;
+  they cannot vouch for a dataset you have not seen.
+
+Optimizer state is deliberately not persisted. Published models are inference artifacts; resuming
+training from a checkpoint is not a supported workflow.
+
+## Versioned schemas
+
+Artifact and contract schemas are versioned, and a breaking change bumps the version rather than
+reinterpreting old data. Two bumps to be aware of when reading older artifacts:
+
+- **Feature transform schema 1 → 2.** Version 2 quantises the fitted statistics before hashing
+  them into `transform_id`. Transform IDs published under version 1 do not match their version 2
+  recomputation.
+- **Torch training config 1 → 2.** Version 2 adds `shuffle_buffer_batches`. Configs persisted
+  under version 1 lack the field and will not load.
+
+Both changes exist so that recorded provenance determines the result. A reproducibility record
+that does not is not one.
+
+## Promotion
+
+A mutable alias can point at a published model so downstream work refers to "the current model"
+rather than an identity string. The alias is validated against the artifact it names, and the
+artifact itself stays immutable — promotion moves a pointer, it never rewrites a run.

--- a/docs/source/ml/index.md
+++ b/docs/source/ml/index.md
@@ -9,12 +9,20 @@ evaluation, interpretability, and immutable artifacts.
 architecture
 quickstart
 plan_reference
+splits_and_masks
+interpretability
+artifacts_and_trust
 performance
 ```
 
 Training something for the first time, start with the [quick start](quickstart.md).
 Wanting the design rationale, start with [architecture and ownership](architecture.md). Sizing a run, or
 wondering why a read was refused, start with [performance and limits](performance.md).
+
+Working out why a split, balancing choice, or mask behaves as it does, see
+[splits, balancing, and masks](splits_and_masks.md). Choosing an attribution method, see
+[interpretability](interpretability.md). Loading a model someone else produced, see
+[artifacts, provenance, and trust](artifacts_and_trust.md).
 
 Migrating from the legacy `analysis.compute.ml_*` entry points is covered by the
 [ML migration guide](../tutorials/ml_migration.md).

--- a/docs/source/ml/interpretability.md
+++ b/docs/source/ml/interpretability.md
@@ -1,0 +1,86 @@
+# Choosing an interpretability method
+
+Attribution methods answer different questions, and most disagreement between them is the methods
+answering different questions rather than one being wrong. This page is about picking the one that
+matches your question.
+
+## Start from the question
+
+| Your question | Method | Backend |
+| --- | --- | --- |
+| Which features does this linear or NB model weight, globally? | `NaiveBayesLogOdds`, `LinearCoefficients` | sklearn |
+| How much does each feature actually contribute to held-out performance? | `PermutationImportance` | sklearn |
+| How did this tree ensemble reach this prediction? | `TreeSHAP` | sklearn |
+| Which positions drove *this read's* prediction? | `Saliency`, `InputXGradient` | Torch |
+| Same, but with a defensible attribution baseline | `IntegratedGradients`, `DeepLift`, `GradientSHAP` | Torch |
+| Which regions does a convolutional layer respond to? | `LayerGradCam`, `GuidedGradCam` | Torch |
+
+## Global structure versus per-read explanation
+
+`NaiveBayesLogOdds` and `LinearCoefficients` read parameters out of a fitted model. They are exact,
+free, and describe the model globally — they say nothing about an individual read.
+
+`PermutationImportance` measures something different and often more useful: how much held-out
+performance degrades when a feature is shuffled. It is computed on validation or test rows, never
+train, so it reports what a feature is worth to generalisation rather than to memorisation. It
+costs one evaluation pass per permuted feature.
+
+The gradient methods are per-observation. They tell you which positions moved *this* prediction,
+which is what you want when asking why one molecule was called active.
+
+## Baselines are a scientific choice
+
+`IntegratedGradients`, `DeepLift`, and `GradientSHAP` attribute relative to a **baseline** — an
+input representing "absent". The attribution is a comparison, so the baseline is part of the
+result's meaning, not a tuning parameter.
+
+The package requires a checksummed **training background** for these methods and records its
+identity in the result. A request that declares a baseline without supplying the background raises,
+and so does the reverse. That is deliberate: an attribution whose baseline you cannot reconstruct
+is not reproducible.
+
+`Saliency` and `InputXGradient` need no baseline, which makes them cheaper and easier to interpret,
+but they are local gradients — they describe sensitivity at the current input, not contribution
+relative to anything.
+
+## Masks are respected, not silently averaged
+
+Attributions are zeroed at positions that are not observed, not available, outside the read's span,
+or not design sites for the channel. An unobserved position gets no attribution rather than an
+attribution of zero that reads as "no effect" — the distinction matters when a fifth of a read is
+unmeasured.
+
+## Chunk size changes results
+
+`example_batch_size` controls how many observations are attributed at once. Two properties are easy
+to get wrong:
+
+- **Wall time has an interior optimum. Larger is not faster.** Measured over 400 rows × 400
+  positions with Saliency, a chunk of 8 was fastest; 1 took 1.99× longer and 512 took 2.76× longer.
+- **It changes attribution values.** Results repeat bitwise at a fixed chunk size but differ by
+  roughly 1.1×10⁻³ relative across chunk sizes, consistent with batch-size-dependent kernel
+  selection accumulating through the network.
+
+Provenance stays honest — `example_batch_size` is part of the request and therefore its identity,
+so two chunk sizes are recorded as different results rather than colliding. But **pick one and hold
+it across runs you intend to compare**, or you are comparing attributions that differ for a reason
+unrelated to your biology.
+
+## Optional dependencies and capability gating
+
+Captum backs the neural methods and SHAP backs `TreeSHAP`. Both are optional `ml-extended`
+dependencies, imported lazily *after* the model, request, schema, masks, layer, parameters, and
+background have passed preflight — so a missing extra fails with an actionable message rather than
+an import error partway through a run.
+
+Methods are also gated on model capability. `LayerGradCam` is available only for a model declaring
+a compatible convolutional `attribution_layer`. Attention-based explanations are **not available**:
+no registered model exposes validated attention, and raw attention weights are not emitted as
+explanations, because attention is not by itself an explanation of a prediction.
+
+## Reading the result
+
+An `AttributionResult` carries values aligned to genomic positions and channels, the request that
+produced it, and — where the method supports it — a convergence delta. Check the delta for
+`IntegratedGradients`: a large value means the integral did not converge and the attribution should
+not be trusted at face value.

--- a/docs/source/ml/splits_and_masks.md
+++ b/docs/source/ml/splits_and_masks.md
@@ -1,0 +1,127 @@
+# Splits, balancing, and masks
+
+The three things most likely to make a result quietly wrong. Each is enforced by the package
+rather than left to discipline, and this page says where the enforcement stops.
+
+## Splits are resolved on groups, never rows
+
+A split assigns whole **groups** to roles. A group is defined by `group_by` — typically
+`["sample_id"]`, meaning a biological or technical replicate.
+
+```python
+"splits": {
+    "by_replicate": {"strategy": "leave_one_group_out", "group_by": ["sample_id"]}
+}
+```
+
+A group cannot appear in two roles. Attempting it raises rather than warning, so the common
+failure mode — reads from one replicate landing in both train and test, inflating every metric —
+is unrepresentable rather than discouraged.
+
+Three strategies:
+
+| Strategy | Use when |
+| --- | --- |
+| `explicit_groups` | You know exactly which replicates are train, validation, and test. |
+| `leave_one_group_out` | You want per-replicate folds and an honest estimate of cross-replicate generalisation. |
+| `stratified_group` | You want seeded proportional assignment; set `fractions`. |
+
+**Grouping is only as good as the field.** If `sample_id` does not actually separate the thing you
+want to generalise across — two libraries from one animal, say — the split is group-disjoint and
+still leaky. The package enforces disjointness of the field you name; it cannot know whether you
+named the right one.
+
+## Balancing: train may be reshaped, evaluation may not
+
+```python
+"balancing": {"weighted": {"train": {"method": "class_weight"}}}
+```
+
+| Role | Allowed methods |
+| --- | --- |
+| `train` | `natural`, `class_weight`, `weighted_sampler`, `downsample`, `upsample` |
+| `validation`, `test` | `natural` only |
+
+Evaluation cohorts keep their real prevalence. Asking to resample them is an error, not a warning,
+because a balanced test set silently changes what precision and recall mean.
+
+Choosing a train method:
+
+- `class_weight` — reweights the loss. Keeps every row. The usual first choice.
+- `downsample` — discards majority rows. Fast, throws away data.
+- `upsample` — repeats minority rows. Keeps data, risks overfitting the repeats.
+- `weighted_sampler` — Torch only, and **incompatible with streaming**, because it samples with
+  replacement across the whole split and therefore needs random access.
+
+Whatever you choose, the resolution is recorded: `result.balance.resolution_id` covers the
+selected indices, the counts, and the seed.
+
+## Masks: seven declarable kinds, four produced
+
+Masks keep distinct meanings distinct instead of folding them into the signal. The input schema
+declares them, and there are seven kinds:
+
+`observed`, `availability`, `design`, `padding`, `attention`, `corruption`, `loss`
+
+The partition data plane produces **four**:
+
+| Kind | Meaning |
+| --- | --- |
+| `observed` | This position was actually measured for this read. |
+| `availability` | This channel is available for this read at all. |
+| `design` | This position is a design site for the channel's site context — a GpC for accessibility, a CpG for endogenous methylation. |
+| `padding` | This position lies outside the read's span. |
+
+They are separate on purpose. A position can be a design site that was not observed, which is not
+the same as a position that was observed as zero, which is not the same as a position outside the
+read. Collapsing them into one "missing" flag loses the distinction that makes SMF data
+interpretable.
+
+:::{warning}
+The remaining three kinds — `attention`, `corruption`, and `loss` — are part of the declared
+vocabulary but are **not produced by the partition reader**. `MLPartitionBatch.mask_arrays`
+returns only the four kinds above; a declared mask of another kind is silently omitted rather
+than rejected. `corruption` is reserved for pretraining, which is scoped but not built, and
+`attention` for attention-capable models, of which none are registered. Declare only the four
+produced kinds unless you are building the machinery that produces the others.
+:::
+
+## Transforms are fitted on train rows only
+
+`fit_feature_transform` refuses any role other than `train`. There is no flag to relax it.
+
+The fitted state — per-column fill values, and centres and scales when standardising — is
+content-addressed as `transform_id`, computed from declared content rather than execution
+strategy. Reading in batches of 16 or 512, or streaming rather than materialising, produces the
+same identity for the same rows.
+
+Streaming a fit costs a number of passes that depends entirely on the spec, and the default costs
+none:
+
+| `imputation` / `scaling` | Data passes |
+| --- | --- |
+| `constant` / `none` (default) | **0** — both statistics are declared, not learned |
+| `constant` / `standard` | 1 |
+| `mean` or `most_frequent` / `none` | 1 |
+| `mean` or `most_frequent` / `standard` | 2 |
+| `median` / any | refused — an exact median needs the whole column in memory |
+
+`median` is refused for a streamed fit rather than approximated, because a near-median statistic
+would change fitted models with no signal to the caller. Use `mean` or `most_frequent`, or
+materialise the split if the median is scientifically required and the split fits.
+
+## What is enforced, and what is not
+
+Enforced:
+
+- group-disjoint splits;
+- natural prevalence in validation and test;
+- train-only transform fitting;
+- the locked test role, unread until early stopping has selected the best validation state.
+
+Not enforced, and yours to get right:
+
+- whether `group_by` names the axis you actually need to generalise across;
+- whether the label column means what you think across every experiment in a project;
+- whether a class present in train is present in validation and test — absent classes raise, but a
+  class down to two reads will pass and tell you very little.

--- a/tests/unit/machine_learning/test_ml_documented_mask_contract.py
+++ b/tests/unit/machine_learning/test_ml_documented_mask_contract.py
@@ -1,0 +1,55 @@
+"""The mask contract stated in docs/source/ml/splits_and_masks.md, asserted.
+
+That page carries a warning: seven mask kinds are declarable, the partition
+reader produces four, and a declared mask of another kind is silently omitted
+rather than rejected. Users are told to declare only the produced four.
+
+If production is ever added for ``attention``, ``corruption``, or ``loss``, the
+warning becomes wrong and misleading. This fails when that happens.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from smftools.machine_learning.contracts import MASK_KINDS
+from smftools.machine_learning.data.partition_dataset import MLPartitionBatch
+
+pytestmark = pytest.mark.unit
+
+DOC_PAGE = Path("docs/source/ml/splits_and_masks.md")
+
+DECLARABLE = {"observed", "availability", "design", "padding", "attention", "corruption", "loss"}
+PRODUCED = {"observed", "availability", "design", "padding"}
+
+
+def test_the_declarable_mask_vocabulary_is_unchanged() -> None:
+    assert set(MASK_KINDS) == DECLARABLE
+
+
+def test_the_batch_carries_exactly_the_produced_kinds() -> None:
+    fields = {name for name in MLPartitionBatch.__dataclass_fields__ if name.endswith("_mask")}
+
+    assert fields == {f"{kind}_mask" for kind in PRODUCED}
+
+
+def test_declarable_but_unproduced_kinds_are_still_unproduced() -> None:
+    # The documented warning exists because these three are accepted by the
+    # schema and then silently dropped by mask_arrays. When one gains a
+    # producer, update the page before deleting this.
+    unproduced = DECLARABLE - PRODUCED
+
+    assert unproduced == {"attention", "corruption", "loss"}
+    for kind in unproduced:
+        assert f"{kind}_mask" not in MLPartitionBatch.__dataclass_fields__
+
+
+def test_the_page_documenting_this_still_exists_and_warns() -> None:
+    assert DOC_PAGE.is_file(), f"{DOC_PAGE} is gone; this test pins claims made there"
+    text = DOC_PAGE.read_text(encoding="utf-8")
+
+    assert "silently omitted" in text, (
+        "the page must keep warning that unproduced mask kinds are dropped without error"
+    )


### PR DESCRIPTION
Third of four ML-701 documentation PRs. Adds the three guidance pages: splits/balancing/masks, choosing an interpretability method, and artifacts/provenance/trust. Seven ML pages now build under sphinx -W.

Each page says where enforcement stops, not only where it holds. The splits page states plainly that group disjointness is only as good as the group_by field: the package enforces disjointness of the field you name and cannot know whether you named the axis you actually need to generalise across. Two libraries from one animal split by sample_id are group-disjoint and still leaky. Documentation that only lists guarantees invites exactly that mistake.

Found while writing: the mask vocabulary declares seven kinds but the partition reader produces four. MLPartitionBatch.mask_arrays filters on "if mask.kind in values", so a declared attention, corruption, or loss mask is silently omitted -- no error, no mask, no warning. corruption is reserved for pretraining that is scoped but not built, and attention for models that are not registered. The page carries this as a warning telling users to declare only the four produced kinds, and test_ml_documented_mask_contract.py pins it so the warning cannot outlive the behaviour: if production is ever added for one of the three, the test fails rather than the page quietly becoming wrong.

Whether silent omission should instead raise is left as an open question for ML-702 rather than changed here, since it is a contract change and this is a documentation PR.

The interpretability page is organised by question rather than by method, since most disagreement between attribution methods is them answering different questions. It records that baselines are a scientific choice rather than a tuning parameter, that chunk size changes attribution values by ~1e-3 relative so it must be held fixed across comparable runs, and that attention-based explanations are unavailable because raw attention weights are not an explanation of a prediction.

The artifacts page separates what the trust boundary buys from what it does not: skops type review and weights_only loading protect against a tampered model file executing code, and say nothing about whether a model is scientifically sound or trained on the data its manifest claims.

Validation: sphinx-build -W exits 0 across seven ML pages; build artifacts cleaned per docs/source/AGENTS.md; 4 new tests; per-PR selection 1659 passed, 9 skipped, 7 xfailed.