### PR TITLE
Add curated ML API reference and workflow tutorials

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -15,6 +15,7 @@ tools
 analysis
 plotting
 datasets
+machine_learning
 ```
 
 ## Informatics module diagram

--- a/docs/source/api/machine_learning.md
+++ b/docs/source/api/machine_learning.md
@@ -1,0 +1,218 @@
+# Machine learning API
+
+Reference for `smftools.machine_learning`. For orientation start with the
+[architecture guide](../ml/architecture.md); for a worked path start with the
+[quick start](../ml/quickstart.md).
+
+## Contracts and plans
+
+Schemas, plans, manifests, workspace resolution, and row selection.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.contracts
+   smftools.machine_learning.manifests
+   smftools.machine_learning.plan
+   smftools.machine_learning.selection
+   smftools.machine_learning.splitting
+   smftools.machine_learning.workspace
+```
+
+## Data plane
+
+Partition reads, fitted transforms, and train-only balancing.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.data.balancing
+   smftools.machine_learning.data.materialized_dataset
+   smftools.machine_learning.data.partition_dataset
+   smftools.machine_learning.data.preprocessing
+   smftools.machine_learning.data.streaming_transforms
+   smftools.machine_learning.data.transforms
+```
+
+## Model families and registry
+
+Registered architectures, recipes, and artifact persistence.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.models.base
+   smftools.machine_learning.models.cnn
+   smftools.machine_learning.models.mlp
+   smftools.machine_learning.models.positional
+   smftools.machine_learning.models.protocols
+   smftools.machine_learning.models.registry
+   smftools.machine_learning.models.residual_cnn
+   smftools.machine_learning.models.rnn
+   smftools.machine_learning.models.sklearn_artifacts
+   smftools.machine_learning.models.sklearn_models
+   smftools.machine_learning.models.torch_artifacts
+   smftools.machine_learning.models.transformer
+   smftools.machine_learning.models.wrappers
+```
+
+## Training engines
+
+sklearn and plain-PyTorch fits, materialized and streaming.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.training.sklearn_backend
+   smftools.machine_learning.training.torch_backend
+```
+
+## Inference
+
+Backend adapters and prediction records.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.inference.inference_utils
+   smftools.machine_learning.inference.lightning_inference
+   smftools.machine_learning.inference.sklearn_backend
+   smftools.machine_learning.inference.sklearn_inference
+   smftools.machine_learning.inference.torch_backend
+```
+
+## Evaluation
+
+Predictor-neutral metrics, curves, folds, and histories.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.evaluation.contracts
+   smftools.machine_learning.evaluation.eval_utils
+   smftools.machine_learning.evaluation.evaluators
+   smftools.machine_learning.evaluation.history
+   smftools.machine_learning.evaluation.metrics
+```
+
+## Interpretability
+
+Attribution requests, results, and backend adapters.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.interpretability.artifacts
+   smftools.machine_learning.interpretability.background
+   smftools.machine_learning.interpretability.classical
+   smftools.machine_learning.interpretability.contracts
+   smftools.machine_learning.interpretability.neural
+```
+
+## Artifacts
+
+Immutable run, model, and result publication.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.artifacts.common
+   smftools.machine_learning.artifacts.indexing
+   smftools.machine_learning.artifacts.model
+   smftools.machine_learning.artifacts.publication
+   smftools.machine_learning.artifacts.results
+   smftools.machine_learning.artifacts.run
+```
+
+## Orchestration
+
+Backend-neutral job services, planning, and dispatch.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.orchestration.actions
+   smftools.machine_learning.orchestration.contracts
+   smftools.machine_learning.orchestration.planning
+   smftools.machine_learning.orchestration.resolution
+   smftools.machine_learning.orchestration.service
+```
+
+## Compatibility
+
+Temporary adapters for the deprecated legacy surface.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.compatibility.classical_explanations
+   smftools.machine_learning.compatibility.classical_models
+   smftools.machine_learning.compatibility.matrix_cnn
+```
+
+## Benchmarks
+
+Operator-invoked scale qualification. Not imported by pipeline code.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.benchmarks.fixtures
+   smftools.machine_learning.benchmarks.harness
+   smftools.machine_learning.benchmarks.sweeps
+```
+
+## Utilities
+
+Device resolution and small shared helpers.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/machine_learning
+   :recursive:
+
+   smftools.machine_learning.utils.device
+   smftools.machine_learning.utils.grl
+```
+
+## Not listed here
+
+Five modules are excluded because they cannot be imported under the documentation
+build's mocked optional dependencies, and all five are surfaces on their way out or
+not yet in:
+
+| Module | Why |
+| --- | --- |
+| `data.anndata_data_module` | Legacy AnnData/Lightning data module; deprecated with a 3.0 removal window |
+| `inference.sliding_window_inference` | Legacy inference helper; deprecated |
+| `models.lightning_base` | PyTorch Lightning wrapper; Lightning is a deferred integration |
+| `training.train_lightning_model` | Legacy Lightning trainer; deprecated |
+| `training.train_sklearn_model` | Legacy sklearn trainer; deprecated |
+
+Each subclasses a base from a package that the docs build mocks, and subclassing a
+mock raises under Python 3.12. Since every one is either deprecated or gated behind
+an integration that is not built, documenting them would advertise surfaces callers
+should not adopt. The replacements are in the
+[migration guide](../tutorials/ml_migration.md).

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -8,6 +8,8 @@ cli_usage
 experiment_config
 semantic_variant_workflows
 pipeline_lifecycle
+ml_experiment_workflow
+ml_project_workflow
 ml_migration
 ```
 
@@ -18,5 +20,8 @@ ml_migration
 - Experiment configuration CSV layout and field descriptions.
 - Semantic planning, immutable preprocess generations, and integrated variant analysis.
 - Pipeline restart, latent-coordinate ownership, model trust, and migration.
+- Training a classifier on one preprocessed experiment, end to end.
+- Pooling several experiments into one model, and the identity and grouping decisions that only
+  appear at project scope.
 - Migration from legacy AnnData, Lightning, analysis-owned training, and wrapper APIs to canonical
   ML plans, datasets, services, artifacts, evaluation, and explanation results.

--- a/docs/source/tutorials/ml_experiment_workflow.md
+++ b/docs/source/tutorials/ml_experiment_workflow.md
@@ -1,0 +1,172 @@
+# Tutorial: training a model on one experiment
+
+Walking a classifier from a preprocessed experiment to a published model with traceable
+provenance.
+
+:::{note}
+This is a narrative walkthrough against **your own** preprocessed experiment, not a runnable
+notebook — the ML data plane reads partitioned stores, and no bundled dataset is one. Every call
+shown is current API; the data is yours.
+:::
+
+## Before you start
+
+You need an experiment that has been through `preprocess`, so that a stage spine and partition
+store exist. The ML layer reads those; it does not read raw BAMs or a monolithic `.h5ad`.
+
+You also need a label. Classification needs a column in `obs` that says what each read *is* —
+typically an activity or genotype call — and it needs to be present for the reads you intend to
+train on.
+
+## 1. Decide the biological question first
+
+The plan makes you state the question before any code runs, which is the point. Three decisions
+matter more than anything else you will tune later:
+
+**What are you predicting?** The label column, and what its classes mean.
+
+**What can the model see?** One channel or two. For conversion SMF, `GpC_site_binary` is
+accessibility and `CpG_site_binary` is endogenous methylation. Giving the model both is not
+automatically better — if endogenous methylation trivially separates your classes, you will learn
+that rather than the accessibility biology you were asking about.
+
+**What must it generalise across?** This becomes `group_by`, and it is the decision most often got
+wrong. If you want a model that works on a new replicate, group by replicate. Grouping by
+something finer — read ID, or a field that repeats within a replicate — produces a model that
+looks excellent and generalises to nothing.
+
+## 2. Write the plan
+
+```python
+from smftools.machine_learning.plan import parse_ml_plan
+
+document = {
+    "schema_version": 1,
+    "scope": {"kind": "experiment"},
+    "datasets": {
+        "accessibility": {
+            "modalities": ["conversion"],
+            "channel_policy": "single_modality",
+            "channels": [
+                {
+                    "name": "accessibility",
+                    "biological_role": "accessibility",
+                    "sources": [
+                        {
+                            "modality": "conversion",
+                            "stage": "preprocess",
+                            "layer": "GpC_site_binary",
+                            "site_context": "GpC",
+                        }
+                    ],
+                }
+            ],
+            "labels": {
+                "column": "activity",
+                "classes": {"inactive": 0, "active": 1},
+                "positive_class": "active",
+            },
+        }
+    },
+    "splits": {
+        "by_replicate": {"strategy": "leave_one_group_out", "group_by": ["sample_id"]}
+    },
+    "models": {"nb": {"backend": "sklearn", "family": "bernoulli_nb"}},
+    "jobs": {
+        "train_nb": {
+            "action": "train",
+            "dataset": "accessibility",
+            "split": "by_replicate",
+            "models": ["nb"],
+        }
+    },
+}
+
+plan = parse_ml_plan(document)
+```
+
+Start with `bernoulli_nb`. It is fast, it streams, and its explanations are exact rather than
+approximate — which makes it a good instrument for finding out whether your labels and channels
+make sense before you spend time on a CNN.
+
+## 3. Dry run
+
+```python
+from smftools.machine_learning.orchestration import plan_ml_workflow
+
+report = plan_ml_workflow(plan, experiment_config=config)
+```
+
+Read the selection counts before anything else. The common surprises:
+
+- **Far fewer rows than expected** — a reference or sample filter is excluding more than intended,
+  or labels are missing for most reads and being dropped.
+- **A class absent from a role** — one replicate has only one class, so leave-one-out folds cannot
+  evaluate. This raises rather than producing a meaningless metric.
+- **Wildly uneven groups** — one replicate dominating training means a leave-one-out fold on it is
+  the only honest estimate you have.
+
+Fix these here. They are cheap now and expensive after a long read.
+
+## 4. Train
+
+```python
+from smftools.machine_learning.models.registry import BUILTIN_MODEL_REGISTRY
+from smftools.machine_learning.orchestration import train_partition_model
+
+resolved = BUILTIN_MODEL_REGISTRY.resolve(
+    "bernoulli_nb", input_schema=dataset.plan.dataset.input_schema
+)
+result = train_partition_model(dataset, resolved)
+```
+
+`bernoulli_nb` declares `incremental_fit`, so this streams and has no row ceiling. Nothing to
+configure.
+
+If you switch to `random_forest` or `logistic_regression`, training materialises the train split
+and is bounded — around 51,000 rows at 1,000 positions with one channel. Above that it refuses and
+names the alternatives. See [performance and limits](../ml/performance.md).
+
+## 5. Read the result honestly
+
+```python
+result.balance.result_counts          # class counts actually trained on
+result.model.transform.transform_id   # fitted preprocessing, train rows only
+result.model.split_id                 # which membership
+```
+
+A leave-one-group-out plan gives one fold per replicate. **Look at the spread, not the mean.** If
+three replicates score 0.85 and one scores 0.55, the honest summary is "works on three of four
+replicates and we do not know why the fourth differs" — not 0.775.
+
+## 6. Ask what the model learned
+
+For a Bernoulli NB, per-feature log odds are exact and free:
+
+```python
+"jobs": {
+    "explain_nb": {
+        "action": "explain",
+        "dataset": "accessibility",
+        "model": "nb",
+        "source_job": "train_nb",
+        "explain": ["NaiveBayesLogOdds"],
+    }
+}
+```
+
+Attributions are aligned to genomic coordinates, so you can ask whether the positions the model
+weights correspond to a footprint you recognise. If the model is accurate but its weight sits on
+positions with no biological interpretation, that is worth understanding before trusting it —
+often it is a batch or coverage artefact tracking your label.
+
+`PermutationImportance` answers a different and usually more useful question: how much held-out
+performance actually depends on a feature. It is computed on validation or test rows, never train.
+See [choosing an interpretability method](../ml/interpretability.md).
+
+## Where to go next
+
+- Scaling to many experiments: [project-level tutorial](ml_project_workflow.md).
+- Why a split, balancing choice, or mask behaves as it does:
+  [splits, balancing, and masks](../ml/splits_and_masks.md).
+- Publishing and loading models: [artifacts, provenance, and trust](../ml/artifacts_and_trust.md).

--- a/docs/source/tutorials/ml_project_workflow.md
+++ b/docs/source/tutorials/ml_project_workflow.md
@@ -1,0 +1,130 @@
+# Tutorial: training across a project
+
+Pooling several experiments into one model, and the identity problems that only appear once you do.
+
+:::{note}
+A narrative walkthrough against your own project, like the
+[experiment-local tutorial](ml_experiment_workflow.md). Read that one first — this covers only
+what changes at project scope.
+:::
+
+## What actually changes
+
+Mechanically, very little: the scope becomes `project`, and selection can span experiments.
+
+```python
+"scope": {"kind": "project", "set": "nkg2a_active_vs_inactive"},
+```
+
+Scientifically, three things change, and each has bitten real analyses.
+
+## 1. Read identity must be collision-free
+
+Read IDs are unique within an experiment and **not** across experiments. Two experiments can
+easily contain the same basecaller-assigned read ID for entirely different molecules.
+
+The package keys pooled rows on `molecule_uid`, which combines experiment identity with read
+identity, so a collision is impossible rather than unlikely. You do not have to do anything for
+this — but it is why a project result is keyed the way it is, and why a cached per-experiment
+result computed under bare read IDs cannot be pooled.
+
+If you see an error about molecule identity when pooling, it is this: something upstream was
+computed before identity was collision-free, and it needs recomputing rather than coercing.
+
+## 2. Grouping is a scientific choice, not a formality
+
+At experiment scope, `group_by: ["sample_id"]` usually means "replicate", and that is usually
+right.
+
+At project scope you have to decide what a fold should hold out:
+
+| `group_by` | Holds out | Answers |
+| --- | --- | --- |
+| `["sample_id"]` | One replicate, possibly within the same experiment | Does this generalise to another replicate? |
+| `["experiment_uid"]` | A whole experiment | Does this generalise to another experiment — different day, prep, flow cell? |
+
+**These give very different numbers, and the second is usually the one you want.** A model that
+generalises across replicates within one experiment but collapses on the next experiment has
+learned batch structure. Grouping by experiment is the honest test, and it is the one people skip
+because it scores worse.
+
+The package enforces disjointness of whatever field you name. It cannot tell you that `sample_id`
+does not separate experiments.
+
+## 3. Labels must mean the same thing everywhere
+
+Pooling assumes `activity == "active"` means the same thing in every experiment. That assumption
+is easy to violate quietly:
+
+- a threshold that drifted between analyses;
+- a class name reused for a different construct;
+- one experiment labelled by a different person or method.
+
+Nothing in the package can detect this. It will train happily on incoherent labels and give you a
+mediocre model with no indication why. Check the label provenance across experiments before
+pooling; if two experiments labelled differently, either relabel or keep them separate.
+
+## Selecting a cohort
+
+```python
+"datasets": {
+    "reads": {
+        "modalities": ["conversion"],
+        "channel_policy": "single_modality",
+        "experiments": {"include": ["exp_a", "exp_b", "exp_c"]},
+        "samples": {"exclude": ["exp_b_rep2"]},
+        "references": ["6B6_top"],
+        "channels": [...],
+        "labels": {"column": "activity", "classes": {"inactive": 0, "active": 1}},
+    }
+}
+```
+
+Excluding a known-bad replicate here, in the declaration, is better than filtering upstream:
+the exclusion becomes part of the dataset snapshot identity, so the resulting model records that
+it was trained without `exp_b_rep2` rather than leaving that in someone's memory.
+
+## Mixed modalities
+
+If a project spans deaminase and conversion experiments, one biological channel can draw from
+different physical layers per modality:
+
+```python
+{
+    "name": "accessibility",
+    "biological_role": "accessibility",
+    "sources": [
+        {"modality": "deaminase", "stage": "preprocess",
+         "layer": "C_site_binary", "site_context": "C"},
+        {"modality": "conversion", "stage": "preprocess",
+         "layer": "GpC_site_binary", "site_context": "GpC"},
+    ],
+}
+```
+
+Set `channel_policy` to `harmonized` or `union` — `single_modality` is only valid for one
+modality.
+
+This is a genuine scientific claim: that a C site in deaminase data and a GpC site in conversion
+data measure the same underlying accessibility well enough to pool. Sometimes true, sometimes not.
+The `availability` mask records per read which channels were actually available, so the model is
+not fed a fabricated zero where a modality simply cannot measure something — but whether pooling
+is *valid* remains your call.
+
+## Scale
+
+Project cohorts are where the materialisation ceiling starts to matter. At a million reads no
+split materialises, so:
+
+- **sklearn** — use a family declaring `incremental_fit`, which streams by default with no
+  ceiling. `bernoulli_nb` qualifies.
+- **Torch** — pass `TorchTrainOptions(streaming=True)`. Not the default, because a streamed fit
+  shuffles within a buffer and produces different weights from a materialised one.
+
+Size Torch runs empirically: process memory is dominated by model activations, which no budget in
+the data plane estimates. See [performance and limits](../ml/performance.md).
+
+## Where to go next
+
+- [Splits, balancing, and masks](../ml/splits_and_masks.md) — what is and is not enforced.
+- [Artifacts, provenance, and trust](../ml/artifacts_and_trust.md) — what a published model records.

--- a/src/smftools/machine_learning/__init__.py
+++ b/src/smftools/machine_learning/__init__.py
@@ -2,15 +2,28 @@ from __future__ import annotations
 
 from importlib import import_module
 
+# Lazily exposed so that importing ``smftools.machine_learning`` does not pull
+# torch, sklearn, and the partition-store stack into every process. The contract
+# modules are as public as the subpackages -- a caller writing a plan needs
+# ``plan``, and one inspecting provenance needs ``manifests`` and ``artifacts``
+# -- so they are declared here rather than left as undeclared-but-required
+# imports.
 _LAZY_MODULES = {
+    "artifacts": "smftools.machine_learning.artifacts",
+    "contracts": "smftools.machine_learning.contracts",
     "data": "smftools.machine_learning.data",
     "evaluation": "smftools.machine_learning.evaluation",
     "inference": "smftools.machine_learning.inference",
     "interpretability": "smftools.machine_learning.interpretability",
+    "manifests": "smftools.machine_learning.manifests",
     "models": "smftools.machine_learning.models",
     "orchestration": "smftools.machine_learning.orchestration",
+    "plan": "smftools.machine_learning.plan",
+    "selection": "smftools.machine_learning.selection",
+    "splitting": "smftools.machine_learning.splitting",
     "training": "smftools.machine_learning.training",
     "utils": "smftools.machine_learning.utils",
+    "workspace": "smftools.machine_learning.workspace",
 }
 
 
@@ -22,4 +35,4 @@ def __getattr__(name: str):
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
-__all__ = list(_LAZY_MODULES.keys())
+__all__ = sorted(_LAZY_MODULES)

--- a/src/smftools/machine_learning/data/streaming_transforms.py
+++ b/src/smftools/machine_learning/data/streaming_transforms.py
@@ -10,17 +10,15 @@ and ``_raw_feature_rows`` both accept an ``MLPartitionBatch``. Only fitting need
 a bounded implementation, and that is what this module provides.
 
 How many passes a fit costs depends entirely on the spec, and the default spec
-costs none:
+costs none::
 
-===========================  ==============  ======================================
-``imputation`` / ``scaling``  Data passes     Why
-===========================  ==============  ======================================
-``constant`` / ``none``       **0**          Both statistics are declared, not learned
-``constant`` / ``standard``   1              Scaling needs moments of the imputed matrix
-``mean``/``most_frequent`` / ``none``  1   Fill values need per-column statistics
-``mean``/``most_frequent`` / ``standard`` 2  Fill values must be known before imputing
-``median`` / any              refused        Exact median needs the full distribution
-===========================  ==============  ======================================
+    imputation / scaling                      passes  why
+    ----------------------------------------  ------  ----------------------------------
+    constant / none                                0  both statistics are declared
+    constant / standard                            1  scaling needs imputed moments
+    mean or most_frequent / none                   1  fill values need column statistics
+    mean or most_frequent / standard               2  fill values precede imputation
+    median / any                             refused  exact median needs the full column
 
 Because ``FeatureTransformSpec`` defaults to ``imputation="constant"`` and
 ``scaling="none"``, the common case resolves the entire transform from read-plan

--- a/tests/unit/machine_learning/test_ml_api_surface.py
+++ b/tests/unit/machine_learning/test_ml_api_surface.py
@@ -1,0 +1,111 @@
+"""The documented public surface and the API-page exclusions, asserted.
+
+Two claims are pinned here.
+
+``docs/source/api/machine_learning.md`` documents 61 of 66 modules and states
+that the five it omits are excluded because they cannot import under the docs
+build's mocked dependencies, *and* that all five are deprecated or gated behind
+an unbuilt integration. That second half is what makes the omission acceptable.
+If a module that is neither ever joins the list, the justification is false.
+
+``machine_learning.__all__`` declares the contract modules a caller actually
+needs. It previously omitted ``plan``, ``contracts``, and ``manifests`` while
+the quick start told readers to import them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import smftools.machine_learning as ml
+
+pytestmark = pytest.mark.unit
+
+API_PAGE = Path("docs/source/api/machine_learning.md")
+PACKAGE_ROOT = Path("src/smftools/machine_learning")
+
+EXPECTED_EXCLUSIONS = {
+    "smftools.machine_learning.data.anndata_data_module",
+    "smftools.machine_learning.inference.sliding_window_inference",
+    "smftools.machine_learning.models.lightning_base",
+    "smftools.machine_learning.training.train_lightning_model",
+    "smftools.machine_learning.training.train_sklearn_model",
+}
+
+REQUIRED_EXPORTS = {
+    "artifacts",
+    "contracts",
+    "data",
+    "evaluation",
+    "inference",
+    "interpretability",
+    "manifests",
+    "models",
+    "orchestration",
+    "plan",
+    "selection",
+    "splitting",
+    "training",
+    "utils",
+    "workspace",
+}
+
+
+def _documentable_modules() -> set[str]:
+    return {
+        ".".join(path.relative_to(Path("src")).with_suffix("").parts)
+        for path in PACKAGE_ROOT.rglob("*.py")
+        if "__pycache__" not in str(path)
+        and path.name != "__init__.py"
+        and not path.name.startswith("_")
+    }
+
+
+def _documented_modules() -> set[str]:
+    text = API_PAGE.read_text(encoding="utf-8")
+    return set(re.findall(r"^\s+(smftools\.machine_learning[\w.]*)$", text, re.M))
+
+
+def test_every_module_is_either_documented_or_a_known_exclusion() -> None:
+    # A new module added to the package must be documented or deliberately
+    # excluded. Silently missing from both is the failure this catches.
+    undocumented = _documentable_modules() - _documented_modules() - EXPECTED_EXCLUSIONS
+
+    assert not undocumented, (
+        f"new modules are neither documented nor listed as exclusions: {sorted(undocumented)}. "
+        f"Add them to {API_PAGE} or justify the exclusion."
+    )
+
+
+def test_the_exclusion_list_has_not_grown() -> None:
+    # The page justifies its five omissions by saying each is deprecated or
+    # gated behind an unbuilt integration. A sixth exclusion for some other
+    # reason breaks that justification, so it has to be a deliberate edit.
+    documented = _documented_modules()
+    excluded = _documentable_modules() - documented
+
+    assert excluded == EXPECTED_EXCLUSIONS
+
+
+def test_the_page_states_why_each_exclusion_is_acceptable() -> None:
+    text = API_PAGE.read_text(encoding="utf-8")
+
+    assert "Not listed here" in text
+    for module in EXPECTED_EXCLUSIONS:
+        leaf = module.rsplit(".", 1)[1]
+        assert leaf in text, f"{leaf} is excluded but not explained on the page"
+    assert "deprecated" in text.lower()
+
+
+def test_public_exports_include_the_contract_modules() -> None:
+    assert set(ml.__all__) == REQUIRED_EXPORTS
+
+
+def test_every_declared_export_actually_resolves() -> None:
+    # __all__ is lazy, so a typo in the module map would only surface on first
+    # access. Force every one.
+    for name in ml.__all__:
+        assert getattr(ml, name) is not None


### PR DESCRIPTION
Last of four ML-701 documentation PRs. Adds docs/source/api/machine_learning.md covering 61 of 66 modules, plus experiment-local and project-level tutorials.

Corrects an earlier estimate. The API blocker was recorded as ten modules that cannot autodoc; measured precisely with sphinx.ext.autodoc.mock per module, it is five. The earlier figure came from grepping for classes subclassing mocked bases, which over-counted: nn.Module and TransformerMixin mocks document fine, and only certain bases (lightning, torch.utils.data.Dataset) raise "__type_params__ must be set to a tuple" under Python 3.12.

That correction matters for more than arithmetic. All five failures -- anndata_data_module, sliding_window_inference, lightning_base, train_lightning_model, train_sklearn_model -- are either deprecated with a 3.0 removal window or gated behind Lightning, which is a deferred integration. Excluding exactly those is defensible; excluding ten arbitrary modules would not have been. The page states the reason per module rather than listing them silently, and test_ml_api_surface.py pins the set so a new module that is neither documented nor deliberately excluded fails rather than disappearing.

Widens machine_learning.__all__ from 8 to 15, adding artifacts, contracts, manifests, plan, selection, splitting, and workspace. The quick start and plan reference already instruct readers to import plan, contracts, and manifests, so the declared public surface was narrower than the documented one. Modules stay lazily imported, so this does not make importing the package heavier.

Adding the API page immediately earned its place: it caught a malformed RST table in streaming_transforms.py, written during ML-204, where the mode -> most_frequent rename pushed two rows past the column margin. That docstring had never been through autodoc because the ML package was not in the API reference, and sphinx -W fails on it. Replaced with a literal block, per docs/source/AGENTS.md.

The tutorials are narrative walkthroughs against the reader's own experiment rather than runnable notebooks, because no bundled dataset is a partitioned store and the ML data plane reads partition stores. They are explicit about that rather than implying a notebook that does not exist. Both spend more space on the decisions that go wrong than on the API: choosing group_by so folds hold out what you actually need to generalise across, and at project scope, that grouping by experiment rather than replicate is usually the honest test and the one people skip because it scores worse.

Validation: sphinx-build -W exits 0 with 61 ML modules documented; build artifacts cleaned; 5 new tests; per-PR selection 1664 passed, 9 skipped, 7 xfailed; integration 46 passed, 2 skipped.