### PR TITLE
Complete ML security review, version matrix, and 2.19.0 release notes

### DIFF
--- a/docs/source/ml/artifacts_and_trust.md
+++ b/docs/source/ml/artifacts_and_trust.md
@@ -75,6 +75,38 @@ reinterpreting old data. Two bumps to be aware of when reading older artifacts:
 Both changes exist so that recorded provenance determines the result. A reproducibility record
 that does not is not one.
 
+## Supported versions
+
+Artifacts record the versions of the packages that produced them, and a load **refuses on any
+mismatch** unless `allow_version_mismatch=True` is passed. The comparison is exact, so a model
+saved under scikit-learn 1.9.0 will not load under 1.9.1 by default.
+
+That is deliberate — a silently different estimator implementation is a reproducibility problem,
+not a convenience — but it means pinning matters for anyone who intends to reload models later.
+
+| Requirement | Declared support | Pinned into artifacts |
+| --- | --- | --- |
+| Python | ≥ 3.11 | no |
+| numpy | ≥ 1.22, < 2 | sklearn artifacts |
+| scipy | ≥ 1.7.3 | sklearn artifacts |
+| scikit-learn | ≥ 1.2 | sklearn artifacts |
+| skops | ≥ 0.10 | sklearn artifacts |
+| torch | ≥ 2.0 | Torch artifacts |
+
+Optional `ml-extended` extras — captum, shap, hydra-core, lightning — are **not** pinned into
+artifacts, because they take no part in producing a fitted model. Captum affects explanations, and
+an explanation records the Captum version in its own result.
+
+## Deprecations
+
+Legacy entry points raise `FutureWarning` naming both the replacement and the removal version.
+Removal is **3.0.0**; nothing is removed in the 2.x line.
+
+The deprecated surface is the analysis-owned ML execution path — `analysis.compute.ml_*` training,
+inference, and explanation entry points — plus the AnnData/Lightning data module and the legacy
+sliding-window and Lightning trainers. See the
+[migration guide](../tutorials/ml_migration.md) for the replacement map.
+
 ## Promotion
 
 A mutable alias can point at a published model so downstream work refers to "the current model"

--- a/docs/source/release-notes/2.19.0.md
+++ b/docs/source/release-notes/2.19.0.md
@@ -1,0 +1,50 @@
+(v2.19.0)=
+
+2.19.0 2026-08-06
+Version 2.19.0 delivers the canonical machine-learning system under `smftools.machine_learning`: typed ML plans, immutable dataset and split manifests, a partition-aware data plane with explicit memory budgets, sklearn and plain-PyTorch training that streams rather than materialising, backend-neutral evaluation and interpretability, immutable content-addressed artifacts, and job services. It also publishes measured scale limits, adds security and path-containment coverage, and documents the whole surface.
+
+## Training runs at experiment scale
+
+Training previously required materialising a whole train split, so it refused above roughly 85,000 rows at 1,000 positions — well below a real experiment of ~10^6 reads. Both backends now fit from streamed batches.
+
+- sklearn families declaring `incremental_fit` stream by default, because a streamed fit is numerically identical to a materialised one.
+- Plain PyTorch streams on request via `TorchTrainOptions(streaming=True)`. It is not the default: a streamed fit shuffles within a buffer rather than globally and therefore produces different weights at the same seed.
+- Materialisation refusals at the training boundary name the streaming remedy rather than reporting a byte count alone.
+
+Train-only transforms fit from batches too. The default spec costs **zero** data passes, because constant fill and no scaling are declared rather than learned. `imputation="median"` is refused under streaming rather than approximated, since a near-median statistic would change fitted models with no signal to the caller.
+
+## Provenance determines the result
+
+Two identity defects were fixed so that a recorded provenance actually pins a result.
+
+- `transform_id` hashed unrounded float64 statistics, so summation order leaked into it and `batch_size` — a pure performance knob — changed a transform's identity and therefore the lineage of every model fitted with it. Statistics are now quantised for hashing only; stored arrays keep full precision.
+- `shuffle_buffer_batches` was a call argument despite changing fitted weights, so two models could share an identical persisted `training_config` and differ. It is now part of that config.
+
+## Measured limits, not estimated ones
+
+Published limits now come from measurement. The analytic memory constants were validated against cold-process peak RSS and hold, with the linear term conservative by roughly 1.6x. Bounded batch reads are demonstrated to plateau independently of split size, and sharding costs nothing in arithmetic terms.
+
+One limit is recorded as **not modelled**: PyTorch process memory is dominated by model activations, which no budget in the data plane estimates, and the ratio to the data estimate is not constant. Size PyTorch training empirically.
+
+## Security and compatibility
+
+- pickle and joblib payloads require an explicit unsafe flag; sklearn artifacts use `skops` with a reviewed type allowlist and no pickle fallback, and Torch artifacts load with `weights_only=True`.
+- Workspace path containment rejects run-id traversal, absolute paths, escaping references, and symlinks that point outside the workspace.
+- Artifacts pin the versions that produced them and refuse to load on mismatch unless explicitly allowed.
+
+## Breaking changes
+
+- `ML_FEATURE_TRANSFORM_VERSION` 1 → 2. Transform IDs published under version 1 do not match their version 2 recomputation.
+- `TORCH_TRAINING_CONFIG_VERSION` 1 → 2. Configs persisted under version 1 lack `shuffle_buffer_batches` and will not load.
+
+Both are development-only artifacts at time of release. Legacy `analysis.compute.ml_*` execution entry points remain available behind `FutureWarning` and are scheduled for removal in 3.0.0.
+
+## Documentation
+
+New `Machine learning` section covering architecture and ownership, a quick start, the plan reference, splits/balancing/masks, interpretability method selection, artifacts and trust, and measured performance limits, plus experiment-local and project-level tutorials and a curated API reference.
+
+## Known limitations
+
+- No CUDA device was available for the scale measurements; the device axis covers CPU and MPS.
+- Explanation memory across chunk sizes is unmeasured.
+- PyTorch Lightning, experiment trackers, and Hydra composition remain deferred integrations. A pretrained-encoder and fine-tuned-head lineage is scoped but not implemented.

--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -2,6 +2,11 @@
 
 # Release notes
 
+### Version 2.19.0
+
+```{include} /release-notes/2.19.0.md
+```
+
 ### Version 2.18.0
 
 ```{include} /release-notes/2.18.0.md

--- a/tests/unit/machine_learning/test_ml_security_boundaries.py
+++ b/tests/unit/machine_learning/test_ml_security_boundaries.py
@@ -1,0 +1,163 @@
+"""Security boundaries for the ML package (ML-702).
+
+Two acceptance criteria are asserted adversarially rather than by reading the
+implementation:
+
+- untrusted pickle/joblib loading is prohibited or requires an explicit opt-in;
+- manifest and path inputs cannot escape the active workspace.
+
+These are regression tests for properties that are cheap to lose. A refactor
+that swaps ``resolve()`` for ``absolute()``, or relaxes a run-id check to allow
+a nested path, would leave every functional test passing and quietly reopen a
+traversal hole.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from smftools.machine_learning.artifacts.common import (
+    MLArtifactManifestError,
+    SerializationPolicy,
+)
+from smftools.machine_learning.workspace import MLWorkspaceError, resolve_ml_workspace
+
+pytestmark = pytest.mark.unit
+
+
+def _workspace(tmp_path: Path):
+    owner = tmp_path / "experiment"
+    owner.mkdir()
+    return resolve_ml_workspace(
+        experiment_config=SimpleNamespace(
+            output_directory=str(owner), experiment_name="experiment-a"
+        )
+    )
+
+
+# --------------------------------------------------------------------------
+# Deserialization trust
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("unsafe_format", ["pickle", "joblib"])
+def test_pickle_and_joblib_policies_require_an_explicit_unsafe_flag(
+    unsafe_format: str,
+) -> None:
+    with pytest.raises(MLArtifactManifestError, match="requires_unsafe_load"):
+        SerializationPolicy(
+            format=unsafe_format,
+            loader=f"{unsafe_format}.load",
+            requires_unsafe_load=False,
+            allowed_types=(),
+            package_versions={},
+        )
+
+
+def test_skops_policies_require_a_reviewed_type_allowlist() -> None:
+    # An empty allowlist would mean "trust whatever is in the payload".
+    with pytest.raises(MLArtifactManifestError, match="allowed_types"):
+        SerializationPolicy(
+            format="skops",
+            loader="skops.io.load",
+            requires_unsafe_load=False,
+            allowed_types=(),
+            package_versions={},
+        )
+
+
+def test_the_canonical_policies_declare_themselves_safe() -> None:
+    torch_policy = SerializationPolicy(
+        format="torch-state-dict",
+        loader="torch.load",
+        requires_unsafe_load=False,
+        allowed_types=(),
+        package_versions={"torch": "2.13.0"},
+    )
+    sklearn_policy = SerializationPolicy(
+        format="skops",
+        loader="skops.io.load",
+        requires_unsafe_load=False,
+        allowed_types=("sklearn.naive_bayes.BernoulliNB",),
+        package_versions={"scikit-learn": "1.9.0"},
+    )
+
+    assert not torch_policy.requires_unsafe_load
+    assert not sklearn_policy.requires_unsafe_load
+
+
+# --------------------------------------------------------------------------
+# Path containment
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "run_id",
+    ["../../outside", "a/../../../outside", "/etc", "..", "nested/run", ""],
+)
+def test_run_ids_must_be_a_single_safe_path_component(tmp_path: Path, run_id: str) -> None:
+    workspace = _workspace(tmp_path)
+
+    with pytest.raises(MLWorkspaceError):
+        workspace.run_paths(run_id)
+
+
+def test_a_legitimate_run_id_still_resolves_inside_the_workspace(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+
+    paths = workspace.run_paths("run-1")
+
+    assert paths.root.is_relative_to(workspace.root)
+
+
+def test_portable_references_reject_paths_outside_the_workspace(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "loot.txt").write_text("x", encoding="utf-8")
+
+    with pytest.raises(MLWorkspaceError, match="escapes"):
+        workspace.portable_reference(outside / "loot.txt")
+
+    with pytest.raises(MLWorkspaceError, match="escapes"):
+        workspace.portable_reference(Path("/etc/passwd"))
+
+
+def test_a_symlink_inside_the_workspace_cannot_smuggle_a_path_out(tmp_path: Path) -> None:
+    # The containment check resolves before comparing, so a link that lives
+    # inside the workspace but points outside is caught. If resolution is ever
+    # replaced with a non-following equivalent, this is the test that fails.
+    workspace = _workspace(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "loot.txt").write_text("x", encoding="utf-8")
+    workspace.root.mkdir(parents=True, exist_ok=True)
+    os.symlink(outside, workspace.root / "sneaky")
+
+    with pytest.raises(MLWorkspaceError, match="escapes"):
+        workspace.portable_reference(workspace.root / "sneaky" / "loot.txt")
+
+
+@pytest.mark.parametrize("reference", ["../../../etc/passwd", "/etc/passwd", "a/../../b"])
+def test_stored_references_cannot_traverse_out_on_the_way_back_in(
+    tmp_path: Path, reference: str
+) -> None:
+    # Resolution is the reverse direction: a manifest written elsewhere, or
+    # edited by hand, must not be able to point a reader outside the workspace.
+    workspace = _workspace(tmp_path)
+
+    with pytest.raises(MLWorkspaceError):
+        workspace.resolve_reference(reference)
+
+
+def test_a_contained_reference_round_trips(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    target = workspace.root / "runs" / "run-1" / "result.json"
+
+    reference = workspace.portable_reference(target)
+
+    assert workspace.resolve_reference(reference) == target


### PR DESCRIPTION
ML-702, the final package of the ML program. The security and containment review was performed adversarially rather than by reading the implementation, because a review that only reads code cannot distinguish a boundary that holds from one that happens to look right.

Deserialization: every site in the ML package is safe. Plan YAML uses yaml.SafeLoader; sklearn artifacts use skops with a reviewed type allowlist and no pickle fallback; Torch artifacts load with weights_only=True. Pickle and joblib serialization policies refuse construction without an explicit unsafe flag, and both loaders refuse a policy that declares one.

Path containment rejected every probe: run-id traversal ("../../outside", "a/../../../outside", "/etc", "..", nested components, empty), portable references outside the workspace, absolute references, and reverse traversal back in through resolve_reference.

The symlink case is the one worth keeping. A link that lives inside the workspace but points outside is rejected, because containment resolves the path before comparing it to the root. That is correct today and quietly reversible: a refactor swapping resolve() for a non-following equivalent would leave every functional test passing and reopen the hole. It is now a committed probe rather than a property nobody is watching.

Adds tests/unit/machine_learning/test_ml_security_boundaries.py with 17 tests covering both criteria.

Documents the supported version matrix and, more usefully, the artifact version policy it implies: artifacts pin the packages that produced them and refuse to load on any mismatch unless allow_version_mismatch is passed, so a model saved under scikit-learn 1.9.0 will not load under 1.9.1 by default. That is deliberate -- a silently different estimator implementation is a reproducibility problem -- but it is a real constraint for anyone planning to reload models later, and it was not written down anywhere.

Adds release-notes/2.19.0.md covering the program, both breaking schema bumps (ML_FEATURE_TRANSFORM_VERSION and TORCH_TRAINING_CONFIG_VERSION, each 1 -> 2, each existing so that recorded provenance determines the result), the deprecation window to 3.0.0, and the known limitations: no CUDA measurements, unmeasured explanation memory, and Lightning, trackers, Hydra, and pretrained lineage all deferred.

One question is deliberately left open rather than decided here: declared mask kinds that the partition reader does not produce -- attention, corruption, loss -- are silently dropped rather than rejected. Changing that is a contract change, not a release-readiness task.

Validation: Ruff check and format clean; sphinx-build -W exits 0; per-PR selection 1681 passed, 9 skipped, 7 xfailed; integration 46 passed, 2 skipped.