### PR TITLE
chore: start 2.20.0 development

### DIFF
--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.19.0"
+__version__ = "2.20.0.dev0"


### PR DESCRIPTION
Opens the 2.20.0 development line, following the same single-file pattern as PR #432 which opened 2.19.0. v2.19.0 is tagged at 8d33859, so main no longer needs to report a released version.