### PR TITLE
fix: detect empty external-tool output instead of caching it

### DIFF
--- a/src/smftools/informatics/basecalling.py
+++ b/src/smftools/informatics/basecalling.py
@@ -1,6 +1,47 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
+
+from smftools.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def _run_dorado_basecaller(command: list[str], output: str | Path) -> None:
+    """Run one dorado basecalling command, streaming stdout into a BAM.
+
+    Dorado writes the BAM to stdout and diagnostics to stderr, and it exits
+    non-zero without writing anything when it cannot resolve a model or read
+    its inputs. stderr is inherited so long-running progress output stays
+    visible and unbuffered rather than accumulating in memory.
+
+    Args:
+        command: The fully resolved dorado argument vector.
+        output: Path of the BAM file to receive dorado's stdout.
+
+    Raises:
+        RuntimeError: If dorado exits non-zero, or exits zero without writing
+            any output. Either case leaves no usable BAM, so the empty file is
+            removed to keep it from being mistaken for a real basecall.
+    """
+    output = Path(output)
+    logger.info("Running dorado basecalling: %s", " ".join(command))
+    logger.info("Writing dorado basecalls to %s", output)
+    with output.open("wb") as handle:
+        completed = subprocess.run(command, stdout=handle)
+    if completed.returncode != 0:
+        output.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"dorado basecalling failed (exit {completed.returncode}). "
+            "See the dorado output above for the reported cause."
+        )
+    if output.stat().st_size == 0:
+        output.unlink(missing_ok=True)
+        raise RuntimeError(
+            "dorado basecalling reported success but produced an empty BAM. "
+            f"Verify that {command[-1]} contains readable signal data."
+        )
 
 
 def canoncall(
@@ -33,6 +74,9 @@ def canoncall(
     Returns:
         None
             Outputs a BAM file holding the canonical base calls output by the dorado basecaller.
+
+    Raises:
+        RuntimeError: If dorado fails or produces no basecalls.
     """
     output = bam + bam_suffix
     command = [
@@ -54,10 +98,7 @@ def canoncall(
     if emit_moves:
         command.append("--emit-moves")
     command += [model, pod5_dir]
-    command_string = " ".join(command)
-    print(f"Running {command_string}\n to generate {output}")
-    with open(output, "w") as outfile:
-        subprocess.run(command, stdout=outfile)
+    _run_dorado_basecaller(command, output)
 
 
 def modcall(
@@ -92,9 +133,10 @@ def modcall(
     Returns:
         None
             Outputs a BAM file holding the modified base calls output by the dorado basecaller.
-    """
-    import subprocess
 
+    Raises:
+        RuntimeError: If dorado fails or produces no basecalls.
+    """
     output = bam + bam_suffix
     command = [
         "dorado",
@@ -115,6 +157,4 @@ def modcall(
     if emit_moves:
         command.append("--emit-moves")
     command += [model, pod5_dir]
-    print(f"Running: {' '.join(command)}")
-    with open(output, "w") as outfile:
-        subprocess.run(command, stdout=outfile)
+    _run_dorado_basecaller(command, output)

--- a/src/smftools/informatics/raw_intermediate_manifest.py
+++ b/src/smftools/informatics/raw_intermediate_manifest.py
@@ -84,6 +84,35 @@ def artifact_checksum(path: str | Path) -> str:
     raise RawIntermediateError(f"Intermediate artifact is missing: {path}")
 
 
+def _assert_artifact_is_usable(path: str | Path) -> None:
+    """Reject artifacts that cannot represent real external-tool output.
+
+    An external tool that fails silently typically leaves a zero-byte file or
+    an empty directory behind. Both hash to perfectly stable checksums, so
+    checksum validation alone accepts them and every later run reuses the
+    broken artifact instead of recomputing it. No producer in this pipeline
+    emits an empty artifact on success: BAM, POD5, and Parquet all carry magic
+    bytes, and even a fully empty ``DataFrame.to_csv`` writes a newline.
+
+    Args:
+        path: The committed artifact to check.
+
+    Raises:
+        RawIntermediateError: If the artifact is missing, is an empty file, or
+            is a directory containing no files.
+    """
+    path = Path(path)
+    if path.is_file():
+        if path.stat().st_size == 0:
+            raise RawIntermediateError(f"Intermediate artifact is empty: {path}")
+        return
+    if path.is_dir():
+        if not any(child.is_file() for child in path.rglob("*")):
+            raise RawIntermediateError(f"Intermediate artifact directory has no files: {path}")
+        return
+    raise RawIntermediateError(f"Intermediate artifact is missing: {path}")
+
+
 def executable_version(command: str) -> str | None:
     """Return a concise executable version string without failing planning."""
     try:
@@ -229,6 +258,10 @@ def validate_intermediate_commit(
             if relative_path.is_absolute() or ".." in relative_path.parts:
                 return None
             path = root / relative_path
+            # Reject previously committed empty artifacts too, so a cache
+            # poisoned before this check existed heals by recomputing instead
+            # of reusing a silently failed tool's output forever.
+            _assert_artifact_is_usable(path)
             if artifact_checksum(path) != record.get("sha256"):
                 return None
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError, RawIntermediateError):
@@ -292,6 +325,7 @@ def commit_intermediate(
             raise RawIntermediateError(
                 f"Committed intermediate output must be owned by its revision: {path}"
             ) from exc
+        _assert_artifact_is_usable(path)
         records.append(
             {
                 "artifact_id": str(artifact_id),

--- a/tests/unit/informatics/test_basecalling.py
+++ b/tests/unit/informatics/test_basecalling.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+
+from smftools.informatics import basecalling
+
+
+def _fake_run(returncode, stdout_bytes=b""):
+    """Build a subprocess.run stand-in that writes bytes to the stdout handle."""
+
+    def run(command, stdout=None, **kwargs):
+        assert isinstance(command, list)
+        if stdout_bytes:
+            stdout.write(stdout_bytes)
+        return SimpleNamespace(returncode=returncode)
+
+    return run
+
+
+def _canoncall(tmp_path):
+    basecalling.canoncall(
+        str(tmp_path / "models"),
+        "hac",
+        str(tmp_path / "reads.pod5"),
+        None,
+        str(tmp_path / "basecalls"),
+        ".bam",
+    )
+
+
+def _modcall(tmp_path):
+    basecalling.modcall(
+        str(tmp_path / "models"),
+        "hac",
+        str(tmp_path / "reads.pod5"),
+        None,
+        ["5mCG_5hmCG"],
+        str(tmp_path / "basecalls"),
+        ".bam",
+    )
+
+
+@pytest.mark.parametrize("call", [_canoncall, _modcall])
+def test_nonzero_exit_raises_and_leaves_no_output(tmp_path, monkeypatch, call):
+    """dorado exits non-zero without writing a BAM; that must not pass silently."""
+    monkeypatch.setattr(basecalling.subprocess, "run", _fake_run(1))
+
+    with pytest.raises(RuntimeError, match="exit 1"):
+        call(tmp_path)
+
+    assert not (tmp_path / "basecalls.bam").exists()
+
+
+@pytest.mark.parametrize("call", [_canoncall, _modcall])
+def test_empty_output_on_success_raises_and_leaves_no_output(tmp_path, monkeypatch, call):
+    """A zero-exit run that produced no basecalls is still a failure."""
+    monkeypatch.setattr(basecalling.subprocess, "run", _fake_run(0))
+
+    with pytest.raises(RuntimeError, match="empty BAM"):
+        call(tmp_path)
+
+    assert not (tmp_path / "basecalls.bam").exists()
+
+
+@pytest.mark.parametrize("call", [_canoncall, _modcall])
+def test_successful_run_keeps_basecalls(tmp_path, monkeypatch, call):
+    monkeypatch.setattr(basecalling.subprocess, "run", _fake_run(0, b"BAM\x01payload"))
+
+    call(tmp_path)
+
+    assert (tmp_path / "basecalls.bam").read_bytes() == b"BAM\x01payload"

--- a/tests/unit/informatics/test_raw_intermediate_manifest.py
+++ b/tests/unit/informatics/test_raw_intermediate_manifest.py
@@ -1,9 +1,14 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from smftools.informatics.raw_intermediate_manifest import (
     IntermediateSpec,
+    RawIntermediateError,
     alignment_reference_bundle,
+    artifact_checksum,
     commit_intermediate,
     committed_output,
     executable_version,
@@ -124,6 +129,79 @@ def test_force_redo_allocates_revision_without_mutating_commit(tmp_path):
     assert forced.root != committed.root
     assert artifact.read_bytes() == b"original"
     assert forced_artifact.read_bytes() == b"replacement"
+
+
+def test_empty_output_is_never_committed(tmp_path):
+    """A silently failed tool leaves an empty artifact that must not be committed."""
+    spec = _spec()
+    workspace = prepare_intermediate(tmp_path, spec)
+    empty_file = workspace.root / "canonical.bam"
+    empty_file.write_bytes(b"")
+
+    with pytest.raises(RawIntermediateError, match="is empty"):
+        commit_intermediate(workspace, {"bam": empty_file})
+
+    assert not workspace.manifest_path.exists()
+    assert prepare_intermediate(tmp_path, spec).reusable is False
+
+
+def test_empty_directory_output_is_never_committed(tmp_path):
+    spec = _spec()
+    workspace = prepare_intermediate(tmp_path, spec)
+    empty_directory = workspace.root / "mod_beds"
+    empty_directory.mkdir()
+
+    with pytest.raises(RawIntermediateError, match="has no files"):
+        commit_intermediate(workspace, {"mod-beds": empty_directory})
+
+    populated = workspace.root / "mod_tsvs"
+    populated.mkdir()
+    (populated / "ref.tsv").write_text("read_id\n", encoding="utf-8")
+    assert commit_intermediate(workspace, {"mod-tsvs": populated}).exists()
+
+
+def test_previously_committed_empty_artifact_is_not_reused(tmp_path):
+    """A cache poisoned before this check existed must heal, not be reused.
+
+    Reproduces the dorado failure mode: a zero-byte BAM has a perfectly stable
+    checksum, so checksum validation alone accepted the commit and every later
+    run reused it instead of rerunning the basecaller.
+    """
+    spec = _spec()
+    workspace = prepare_intermediate(tmp_path, spec)
+    poisoned = workspace.root / "canonical.bam"
+    poisoned.write_bytes(b"")
+    # Hand-write the manifest that the pre-fix commit path would have published.
+    workspace.manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "state": "complete",
+                "operation": spec.operation,
+                "revision_id": workspace.revision_id,
+                "compatibility_key": spec.compatibility_key,
+                "compatibility": spec.compatibility_payload(),
+                "tool_versions": dict(spec.tool_versions),
+                "outputs": [
+                    {
+                        "artifact_id": "bam",
+                        "path": "canonical.bam",
+                        "kind": "file",
+                        "size_bytes": 0,
+                        "sha256": artifact_checksum(poisoned),
+                    }
+                ],
+                "committed_at": "2026-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert validate_intermediate_commit(workspace.manifest_path, spec) is None
+
+    replacement = prepare_intermediate(tmp_path, spec)
+    assert replacement.reusable is False
+    assert replacement.root != workspace.root
 
 
 def test_reference_bundle_is_relocation_invariant_and_content_sensitive(tmp_path):


### PR DESCRIPTION
A silently failed dorado run left a zero-byte BAM behind, and the intermediate commit contract accepted it: an empty file has a perfectly stable SHA-256, so checksum validation passed and the revision was published as `state: complete`. Every later run then logged "Reusing validated dorado basecalling intermediate" and reused the empty BAM, surfacing three stages downstream as an unrelated
`samtools sort: failed to read header`.

- canoncall/modcall now check dorado's exit status and reject a zero-exit run that produced no basecalls, removing the unusable file rather than leaving it to be mistaken for a real basecall. Both shared the same unchecked `subprocess.run(command, stdout=outfile)`, so the run/verify step is now one helper. stderr stays inherited so long-running progress output does not accumulate in memory.
- commit_intermediate rejects empty file and file-less directory outputs, and validate_intermediate_commit treats them as unusable so a cache poisoned before this check existed heals by recomputing instead of reusing the failure forever.

Verification: 1,769 unit tests pass (9 skipped, 7 xfailed), 49 integration, 106 smoke, repository-wide Ruff check/format, `git diff --check`, and warning-strict Sphinx build. The three pre-existing e2e failures are unchanged in count and now report the absent dorado model directory as their cause instead of the misleading samtools error.