### PR TITLE
feat: record bundle provenance and cover every aligner in workflow ve…

### DIFF
--- a/src/smftools/cli/workflow_contract.py
+++ b/src/smftools/cli/workflow_contract.py
@@ -69,6 +69,11 @@ _RESULT_REQUIRED_FIELDS = frozenset(
 _TOOL_VERSION_COMMANDS = {
     "bedGraphToBigWig": ("bedGraphToBigWig",),
     "bedtools": ("bedtools", "--version"),
+    # bowtie2 builds indexes with a separate binary, and bwa-mem2 reports its
+    # version through a subcommand rather than a --version flag.
+    "bowtie2": ("bowtie2", "--version"),
+    "bowtie2-build": ("bowtie2-build", "--version"),
+    "bwa-mem2": ("bwa-mem2", "version"),
     "dorado": ("dorado", "--version"),
     "gzip": ("gzip", "--version"),
     "minimap2": ("minimap2", "--version"),
@@ -151,14 +156,75 @@ def _source_fingerprint(path: Path) -> dict[str, Any]:
     raise WorkflowContractError(f"staged input does not exist: {path}")
 
 
-def _snapshot_sources(paths: Mapping[str, Path]) -> dict[str, dict[str, Any]]:
+def _bundle_provenance(path: Path) -> dict[str, Any] | None:
+    """Return re-ingestion bundle facts for one staged input, or ``None``.
+
+    A re-ingestion bundle enters the workflow as its ``bundle_manifest.json``,
+    which the raw stage resolves to the bundle's canonical input manifest. The
+    file fingerprint alone cannot express what re-ingesting it costs, so record
+    the declared kind and any capabilities the export dropped. Provenance only:
+    the raw stage performs the authoritative checksum validation, and anything
+    unreadable or non-bundle is reported as absent rather than failing the run.
+
+    Args:
+        path: A staged source path, which may or may not be a bundle manifest.
+
+    Returns:
+        The bundle's kind, scope, modality, lost capabilities, and source
+        generation ids, or ``None`` when *path* is not a readable bundle.
+    """
+    if path.suffix.lower() != ".json":
+        return None
+    try:
+        from ..informatics.export_bundle import BUNDLE_KINDS
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, Mapping) or payload.get("bundle_kind") not in BUNDLE_KINDS:
+        return None
+    generations = payload.get("source_generations")
     return {
-        name: {
+        "bundle_kind": str(payload["bundle_kind"]),
+        "scope": str(payload.get("scope", "")),
+        "modality": str(payload.get("modality", "")),
+        "lost_capabilities": sorted(str(item) for item in (payload.get("lost_capabilities") or ())),
+        "source_generation_ids": sorted(
+            str(item.get("generation_id", ""))
+            for item in (generations if isinstance(generations, list) else ())
+            if isinstance(item, Mapping) and item.get("generation_id")
+        ),
+    }
+
+
+def _snapshot_sources(paths: Mapping[str, Path]) -> dict[str, dict[str, Any]]:
+    snapshot: dict[str, dict[str, Any]] = {}
+    for name, path in sorted(paths.items()):
+        record: dict[str, Any] = {
             "path": str(path),
             "fingerprint": _source_fingerprint(path),
         }
-        for name, path in sorted(paths.items())
-    }
+        bundle = _bundle_provenance(path)
+        if bundle is not None:
+            record["bundle"] = bundle
+        snapshot[name] = record
+    return snapshot
+
+
+def _source_result_records(
+    snapshot: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Project a source snapshot into its workflow-result representation."""
+    records = {}
+    for name, record in snapshot.items():
+        entry: dict[str, Any] = {
+            "kind": record["fingerprint"]["kind"],
+            "fingerprint": record["fingerprint"],
+        }
+        if "bundle" in record:
+            entry["bundle"] = record["bundle"]
+        records[name] = entry
+    return records
 
 
 def _assert_sources_unchanged(snapshot: Mapping[str, Mapping[str, Any]]) -> None:
@@ -326,8 +392,12 @@ def _required_external_tools(cfg: Any, *, raw_will_run: bool) -> tuple[str, ...]
     if input_type == "fast5":
         tools.add("pod5")
     aligner = str(getattr(cfg, "aligner", "") or "").lower()
-    if aligner in {"dorado", "minimap2"}:
+    if aligner in {"dorado", "minimap2", "bwa-mem2"}:
         tools.add(aligner)
+    elif aligner == "bowtie2":
+        # The bowtie2 adapter shells out to bowtie2-build for its native index,
+        # so a host with only the aligner would fail at index-build time.
+        tools.update(("bowtie2", "bowtie2-build"))
     if (
         str(getattr(cfg, "demux_backend", "") or "").lower() == "dorado"
         and getattr(cfg, "barcode_kit", None)
@@ -785,13 +855,7 @@ def run_experiment_workflow(
             "artifacts": artifacts,
             "schemas": schemas,
             "resources": resources,
-            "sources": {
-                name: {
-                    "kind": record["fingerprint"]["kind"],
-                    "fingerprint": record["fingerprint"],
-                }
-                for name, record in source_snapshot.items()
-            },
+            "sources": _source_result_records(source_snapshot),
             "strict": bool(strict),
             "failure": failure,
         }

--- a/tests/unit/test_workflow_contract.py
+++ b/tests/unit/test_workflow_contract.py
@@ -406,6 +406,114 @@ def test_version_plan_covers_configured_external_backends(monkeypatch, tmp_path)
     }
 
 
+@pytest.mark.parametrize(
+    ("aligner", "expected"),
+    [
+        ("minimap2", {"minimap2"}),
+        ("bwa-mem2", {"bwa-mem2"}),
+        # bowtie2 builds its native index with a separate binary.
+        ("bowtie2", {"bowtie2", "bowtie2-build"}),
+    ],
+)
+def test_version_plan_covers_every_supported_aligner(monkeypatch, tmp_path, aligner, expected):
+    cfg = _cfg(tmp_path)
+    cfg.aligner = aligner
+    monkeypatch.setattr(workflow_contract.shutil, "which", lambda name: None)
+
+    tools = set(workflow_contract._required_external_tools(cfg, raw_will_run=True))
+
+    assert expected <= tools
+    assert all(tool in workflow_contract._TOOL_VERSION_COMMANDS for tool in tools)
+
+
+def _write_bundle(root: Path, *, bundle_kind: str = "sequence_only") -> Path:
+    """Build a real, checksum-valid re-ingestion bundle."""
+    from smftools.informatics.export_bundle import (
+        artifact_record,
+        write_bundle_manifest,
+        write_canonical_input_manifest,
+        write_identity_map,
+    )
+
+    root.mkdir(parents=True, exist_ok=True)
+    reads = root / "reads.fastq"
+    reads.write_text("@r1\nACGT\n+\nIIII\n", encoding="utf-8")
+    write_canonical_input_manifest(
+        root / "inputs.csv",
+        [{"path": "reads.fastq", "source_kind": "fastq", "sample": "s", "barcode": "bc01"}],
+        alignment_mode="align",
+        modality="conversion",
+    )
+    write_identity_map(
+        root / "identity_map.csv", [{"bundle_read_id": "r1", "source_read_id": "r1"}]
+    )
+    return write_bundle_manifest(
+        root,
+        bundle_kind=bundle_kind,
+        scope="experiment",
+        modality="conversion",
+        selection={},
+        source_generations=[{"generation_id": "generation-a"}],
+        artifacts=[artifact_record(root, reads)],
+        lost_capabilities=["direct_modification"],
+    )
+
+
+def test_staged_bundle_keeps_relative_artifacts_resolvable(tmp_path):
+    """Staging symlinks the manifest, so bundle-relative artifacts must still resolve.
+
+    The raw stage resolves the manifest path before anchoring relative rows, so a
+    read-only alias outside the bundle still points back into it. Locks that in so
+    hardening the staging path cannot silently break bundle re-ingestion.
+    """
+    from smftools.informatics.input_manifest import resolve_input_manifest_readonly
+
+    bundle_manifest = _write_bundle(tmp_path / "bundle")
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+
+    alias = workflow_contract._stage_readonly_alias(
+        bundle_manifest, runtime_dir, stem="input_manifest"
+    )
+
+    assert alias.suffix == ".json"
+    resolved = resolve_input_manifest_readonly(
+        input_manifest_path=alias, alignment_mode="align", modality="conversion"
+    )
+    assert [Path(row.path).name for row in resolved.rows] == ["reads.fastq"]
+    assert all(Path(row.path).is_file() for row in resolved.rows)
+
+
+def test_source_snapshot_records_bundle_kind_and_lost_capabilities(tmp_path):
+    """A file fingerprint cannot express what re-ingesting a bundle costs."""
+    bundle_manifest = _write_bundle(tmp_path / "bundle")
+
+    snapshot = workflow_contract._snapshot_sources({"input_manifest": bundle_manifest})
+    records = workflow_contract._source_result_records(snapshot)
+
+    bundle = records["input_manifest"]["bundle"]
+    assert bundle["bundle_kind"] == "sequence_only"
+    assert bundle["lost_capabilities"] == ["direct_modification"]
+    assert bundle["source_generation_ids"] == ["generation-a"]
+    assert bundle["modality"] == "conversion"
+    # The ordinary fingerprint contract still applies to the manifest file.
+    assert records["input_manifest"]["fingerprint"] == snapshot["input_manifest"]["fingerprint"]
+
+
+def test_non_bundle_sources_carry_no_bundle_provenance(tmp_path):
+    plain = tmp_path / "inputs.csv"
+    plain.write_text("path\nreads.fastq\n", encoding="utf-8")
+    unrelated_json = tmp_path / "other.json"
+    unrelated_json.write_text('{"schema_version": 1}\n', encoding="utf-8")
+
+    records = workflow_contract._source_result_records(
+        workflow_contract._snapshot_sources({"input_manifest": plain, "sidecar": unrelated_json})
+    )
+
+    assert "bundle" not in records["input_manifest"]
+    assert "bundle" not in records["sidecar"]
+
+
 def test_validation_detects_corruption_and_relocated_output_validates(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
…rsions

Grounding IAR-15 against the code showed the re-ingestion bundle path already works through `experiment run`: staging symlinks the manifest, and because the raw stage resolves the manifest path before anchoring relative rows, a bundle's relative artifacts still resolve back into the bundle. That is now locked in by a test so hardening the staging path cannot silently break it. Two real gaps remained.

- `_required_external_tools` only recognized dorado and minimap2 as aligners, so a run configured for bwa-mem2 or bowtie2 recorded no aligner version at all and strict mode did not check for the binary. All four supported aligners are covered now, including bowtie2-build, which the bowtie2 adapter shells out to for its native index and which is a separate binary. `bwa-mem2` reports through a `version` subcommand, not `--version`. The new test asserts every required tool has a version command, which is the invariant that was violated.
- A source fingerprint cannot express what re-ingesting a bundle costs, so `sources` entries now carry the declared bundle kind, scope, modality, lost capabilities, and source generation ids. This is provenance only: the raw stage still performs the authoritative checksum validation, and a non-bundle or unreadable JSON is reported as absent rather than failing the run. Added as an optional field, so the result schema version is unchanged.

Raw generation ids and input-manifest checksums already reach `workflow_result.json` through the per-stage manifest entries published by IAR-02/IAR-04, so no change was needed there.

Verification: 1,775 unit tests pass (9 skipped, 7 xfailed), 53 integration (up from 49 now that the aligners resolve), 106 smoke, 10 e2e, repository-wide Ruff check/format, `git diff --check`, and warning-strict Sphinx build.