### PR TITLE
docs: describe restart, immutability, and bundle re-ingestion semantics

### DIFF
--- a/docs/source/containers.md
+++ b/docs/source/containers.md
@@ -104,6 +104,25 @@ image name begin with `experiment`, `project`, or `versions`; do not repeat
 `smftools`. `apptainer exec` executes the command supplied to it directly, so
 its example includes the executable.
 
+## Handing an output tree to a later task
+
+A completed output root can be mounted read-only by a later task that runs as a
+different, arbitrary UID and owns none of the files. Validation is defined to
+work under exactly those conditions:
+
+- Every published pointer is relative to the run root, so the tree can be
+  mounted at a different path than the one that produced it.
+- `smftools experiment validate` and raw-generation selection read only; neither
+  needs write access anywhere in the tree.
+- Published artifacts keep their write bit. Immutability is enforced by
+  checksum at selection time rather than by file permissions, precisely so an
+  arbitrary non-owning UID can still manage the directory. See
+  [Immutability, relocation, and container execution](tutorials/pipeline_lifecycle.md#immutability-relocation-and-container-execution).
+
+A task that resumes work in a mounted tree needs it writable, and needs nothing
+else: an earlier task killed mid-stage leaves a resumable record, not a
+directory that has to be discarded.
+
 ## Included and excluded tools
 
 The image is intentionally limited to the CPU BAM-entry profile:

--- a/docs/source/tutorials/cli_usage.md
+++ b/docs/source/tutorials/cli_usage.md
@@ -408,6 +408,25 @@ smftools project export-bundle /path/to/project_dir --outdir ./bundle --format b
   whether the export is unfiltered, source experiment/generation identities, modality, trim state,
   namespaces, and paired layout.
 
+### Re-ingesting a bundle
+
+Point `input_manifest_path` at the bundle's `bundle_manifest.json` and set the alignment mode the
+bundle's declared sources require. The bundle kind decides what the new experiment can do:
+
+| Bundle kind | `alignment_mode` | What re-ingestion gets |
+| --- | --- | --- |
+| `sequence_only` (`--format fastq`) | `align` | Sequence and quality only. The reads are aligned again by the configured aligner, and the new experiment's alignment provenance is its own, not the exporting run's. |
+| `lossless_bam` (`--format bam`) | `existing` | The exported alignment is carried forward and validated, not recomputed. No aligner runs, the source run's `@PG` records survive, coordinates are identical to the exporting generation, and BC/RG/MM/ML tags are preserved. |
+
+A `lossless_bam` bundle re-ingested with `alignment_mode: align` is rejected: its rows declare an
+alignment source role, which conflicts with the read role that `align` expects. A `sequence_only`
+bundle cannot satisfy a direct-modification experiment at all, because sequence carries no MM/ML.
+
+When a bundle is used as the staged input to `experiment run`, `workflow_result.json` records its
+kind, scope, modality, dropped capabilities, and source generation IDs alongside the ordinary file
+fingerprint -- a checksum alone cannot express that re-ingesting a `sequence_only` bundle gives up
+direct-modification capability.
+
 
 ## Batch processing
 

--- a/docs/source/tutorials/pipeline_lifecycle.md
+++ b/docs/source/tutorials/pipeline_lifecycle.md
@@ -71,6 +71,46 @@ pointer advances. The generation manifest records the transition, reused and
 added source IDs, prior generation ID, and reused/new file and byte counts.
 An interrupted append leaves the prior generation selected.
 
+### Resuming an interrupted run
+
+A process that dies mid-stage -- an out-of-memory kill, an evicted container, a
+hard interrupt -- never writes a terminal state, so it leaves the stage record
+in `running`. That is a resumable state, not a corrupt one:
+
+- The next invocation supersedes the abandoned attempt and records it under
+  `superseded_attempt` in the stage entry, so the manifest still shows that
+  something was tried and did not finish.
+- The last complete stage record is retained across the restart. If its
+  published generation still satisfies the request, the run reuses it and
+  promotes that record back to the live state instead of recomputing; the entry
+  is marked `restored_from_previous_complete`.
+- Nothing is skipped on the strength of a non-complete record, so a half-written
+  attempt can never authorize reuse of its own artifacts.
+
+Deleting the run directory or hand-editing `experiment_manifest.json` is not
+part of the recovery path. Re-run the same stage command.
+
+## Immutability, relocation, and container execution
+
+A published raw generation is immutable by validation, not by permissions.
+Every artifact carries a size and SHA-256 checksum, and the current-generation
+pointer carries the manifest checksum, so an edited or truncated artifact is
+detected when the generation is selected and the run refuses it. Artifacts are
+deliberately **not** made read-only on disk: a file whose write bit was stripped
+is unmanageable for the arbitrary, non-owning UID that a container task usually
+runs as.
+
+Because of that, an owned output tree is portable:
+
+- Every pointer inside a generation manifest, the workflow result, and the spine
+  is relative and anchored to the run root, so moving the complete directory to
+  another path -- or another machine -- keeps it selectable and valid.
+- Validation reads only. `smftools experiment validate` works against a
+  read-only mount, and against a tree owned by a different user.
+- Detection is the guarantee, not prevention. Anything that edits a published
+  artifact in place will be caught at selection time rather than blocked at
+  write time.
+
 Partitioned latent output is published as immutable generations. A generation
 becomes current only after its task stores, model bundles, indexes, plots,
 spine pointers, checksums, schemas, source provenance, and completion manifest
@@ -120,6 +160,9 @@ features require `force_recompute=True`.
 
 | Existing artifact or script | Current behavior | Migration |
 | --- | --- | --- |
+| Raw output predating immutable generations (canonical `raw_outputs/spine.h5ad`, no `generations/`) | Migrated into a generation without recomputing when the recorded stage is lifecycle-compatible and every required artifact validates; otherwise recomputed from the declared inputs | Re-run `smftools experiment raw`; keep the original inputs reachable, since an incompatible layout is rebuilt rather than converted |
+| Stage record left in `running` by a killed process | Superseded by the next attempt, which reuses the retained complete generation when it still satisfies the request | Re-run the same stage command; do not delete the run directory |
+| Corrupt or unreadable `current.json` | Fails closed for every downstream consumer rather than falling back to the canonical working files | Re-run `smftools experiment raw`, the one stage authorized to replace an invalid selector |
 | Periodicity cache without experiment and molecule identity | Migrated only when its registered experiment owner is unambiguous | Re-run with `force_recompute=True` if ownership is ambiguous or the cache is rejected |
 | Legacy in-place project embedding directory such as one containing only `meta.json` | Never accepted as a current immutable generation | Refit with `force_recompute=True`; the old directory is retained |
 | Latent output without a completed generation manifest, read index, or model provenance | Never treated as a valid restart or scoped project source | Re-run `smftools experiment latent` in `auto` or `partitioned` mode, then re-run `project add` |


### PR DESCRIPTION
Closes IAR-15's documentation item, written last so it describes shipped behavior. The configuration and CLI references already covered the input manifest, alignment modes, aligners, and export bundles; what nothing described was the lifecycle contract users actually hit when a run dies or an output tree moves.

- pipeline_lifecycle.md: resuming an interrupted run (a killed process leaves a resumable `running` record, the next attempt supersedes it and reuses the retained complete generation, and deleting the run directory is not part of the recovery path), plus the immutability contract -- detection by checksum rather than by permissions, which is what lets an arbitrary non-owning UID manage the tree. Three migration rows for the prior on-disk patterns.
- containers.md: what a later task can assume when it mounts a finished output tree read-only under a different UID.
- cli_usage.md: which alignment mode each bundle kind requires and what re-ingesting it preserves. Verified with a probe that a lossless_bam bundle under `alignment_mode: align` is rejected on the source-role conflict.

Warning-strict Sphinx build passes and the new cross-reference anchor resolves in the built HTML.