### PR TITLE
feat: add named experiment set commands to the project CLI

### DIFF
--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -19,6 +19,15 @@ read-only experiment plan. The compatibility states, force behavior, and
 semantic-versus-execution distinction are described in
 [](tutorials/semantic_variant_workflows.md).
 
+## Named experiment sets
+
+`--set NAME` restricts a project command to a saved subset of the registered
+experiments. Manage those subsets with `project add-set`, `project list-sets`,
+`project show-set`, and `project remove-set`; membership is validated when the
+set is defined, and `show-set` resolves through the same path `--set` applies,
+so what it prints is what a plan or materialize will use. See
+[](tutorials/cli_usage.md#smftools-project).
+
 ## External workflow contract
 
 Workflow engines should use `smftools experiment run` instead of rewriting an

--- a/docs/source/tutorials/cli_usage.md
+++ b/docs/source/tutorials/cli_usage.md
@@ -321,6 +321,25 @@ canonical name even if experiments called it something different.
   [Registering legacy (pre-partitioned-store) runs](directory_organization.md#registering-legacy-pre-partitioned-store-runs).
 - `project list PROJECT_DIR` lists registered experiments (including which stages each has
   reached) and the harmonized reference table.
+- `project add-set PROJECT_DIR NAME` defines a named experiment set for the `--set` flag that
+  `plan`, `materialize`, `export-fastq`, `export-latent`, and the ML selection layer accept. Give
+  it either explicit membership (`--experiment expA --experiment expB`, repeatable) or a saved
+  query over the harmonized reference table (`--query "modality='direct'"`, which needs DuckDB).
+  Definition is validated: naming an experiment that is not registered, has been deactivated, or is
+  repeated fails without writing anything, since a set that silently selects fewer experiments than
+  it names is indistinguishable from a correct one at use time. Pass `--allow-unresolved` to define
+  it anyway, which is what you want when the set is written before the experiments it names are
+  registered.
+- `project list-sets PROJECT_DIR` lists the defined sets without resolving them (cheap; no DuckDB
+  needed even when a query set exists).
+- `project show-set PROJECT_DIR NAME` resolves one set to the experiments it selects, and reports
+  anything declared that does not resolve -- unregistered, deactivated, or duplicated. The
+  resolution shown here is the same code path `--set` applies, so a `materialize --set NAME` pools
+  exactly the experiments listed. A query set can only ever resolve to active experiments, since
+  the harmonized table it queries is built from active registrations.
+- `project remove-set PROJECT_DIR NAME` deletes a set definition. Unlike `project remove`, which
+  deactivates an experiment in the append-only registry, this is a real deletion -- a set is a
+  saved selection, not registered data -- and no experiment registration is touched.
 - `project materialize PROJECT_DIR CANONICAL_REFERENCE -o OUTPUT.h5ad.gz` resolves the canonical
   reference back to each matching experiment's own reference name(s), materializes each
   experiment's slice independently, and concatenates them (adding an `obs["experiment"]` column) --

--- a/src/smftools/cli/project_cmd.py
+++ b/src/smftools/cli/project_cmd.py
@@ -87,6 +87,82 @@ def project_list(project_dir: str | Path):
     return catalog.experiments(), catalog.references()
 
 
+def project_add_set(
+    project_dir: str | Path,
+    name: str,
+    *,
+    experiments: list[str] | None = None,
+    query: str | None = None,
+    allow_unresolved: bool = False,
+):
+    """Define a named experiment set and return its resolved membership.
+
+    Args:
+        project_dir: Project root.
+        name: Set name, as later passed to ``--set``.
+        experiments: Explicit membership. Mutually exclusive with *query*.
+        query: Saved SQL predicate over the harmonized ``refs`` table. Mutually
+            exclusive with *experiments*.
+        allow_unresolved: Define the set even when it names an experiment that is
+            not registered, is deactivated, or is repeated. Useful when the set
+            is written before the experiments it names are registered.
+
+    Returns:
+        The stored :class:`~smftools.project.registry.SetMembership`.
+    """
+    from ..project.registry import add_set, resolve_set_membership
+
+    add_set(
+        project_dir,
+        name,
+        experiments=experiments,
+        query=query,
+        validate=not allow_unresolved,
+    )
+    return resolve_set_membership(project_dir, name)
+
+
+def project_list_sets(project_dir: str | Path) -> list[dict]:
+    """Return one display record per named set, most useful fields first.
+
+    A query set is described but not executed here, so listing stays cheap and
+    does not require DuckDB; use :func:`project_show_set` to resolve one.
+    """
+    from ..project.registry import list_sets
+
+    records = []
+    for name, definition in sorted(list_sets(project_dir).items()):
+        kind = str(definition.get("kind", ""))
+        records.append(
+            {
+                "name": name,
+                "kind": kind,
+                "n_declared": len(definition.get("experiments", ())) if kind == "list" else None,
+                "query": str(definition.get("sql", "")) if kind == "query" else None,
+            }
+        )
+    return records
+
+
+def project_show_set(project_dir: str | Path, name: str):
+    """Return one named set's resolved membership.
+
+    Returns:
+        The :class:`~smftools.project.registry.SetMembership` that every ``--set``
+        consumer resolves to.
+    """
+    from ..project.registry import resolve_set_membership
+
+    return resolve_set_membership(project_dir, name)
+
+
+def project_remove_set(project_dir: str | Path, name: str) -> None:
+    """Delete a named set. No experiment registration is affected."""
+    from ..project.registry import remove_set
+
+    remove_set(project_dir, name)
+
+
 def project_plan(
     project_dir: str | Path,
     target: str,

--- a/src/smftools/cli_entry.py
+++ b/src/smftools/cli_entry.py
@@ -1214,6 +1214,125 @@ def project_sample_store_list_cmd(project_dir: Path, experiment_id):
 ##########################################
 
 
+####### named experiment sets ###########
+@project_group.command("add-set")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("name")
+@click.option(
+    "--experiment",
+    "experiments",
+    multiple=True,
+    help="Experiment ID to include; repeat for multiple. Mutually exclusive with --query.",
+)
+@click.option(
+    "--query",
+    default=None,
+    help="Saved SQL predicate over the harmonized refs table, e.g. \"modality='direct'\".",
+)
+@click.option(
+    "--allow-unresolved",
+    is_flag=True,
+    help="Define the set even if it names an unregistered, inactive, or repeated experiment.",
+)
+def project_add_set_cmd(project_dir: Path, name, experiments, query, allow_unresolved):
+    """Define a named experiment set usable as --set by other project commands."""
+    from .cli.project_cmd import project_add_set
+    from .project.registry import SetMembershipError
+
+    if bool(experiments) == bool(query):
+        raise click.ClickException("provide exactly one of --experiment or --query")
+    try:
+        membership = project_add_set(
+            project_dir,
+            name,
+            experiments=list(experiments) if experiments else None,
+            query=query,
+            allow_unresolved=allow_unresolved,
+        )
+    except SetMembershipError as exc:
+        raise click.ClickException(
+            f"{exc}. Register the experiments first, correct the name, "
+            f"or pass --allow-unresolved to define the set anyway."
+        ) from exc
+    click.echo(f"Defined set '{name}' ({membership.kind}).")
+    _echo_set_membership(membership)
+
+
+@project_group.command("list-sets")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+def project_list_sets_cmd(project_dir: Path):
+    """List named experiment sets without resolving them."""
+    from .cli.project_cmd import project_list_sets
+
+    records = project_list_sets(project_dir)
+    if not records:
+        click.echo("No named sets defined. Create one with `smftools project add-set`.")
+        return
+    click.echo(f"{len(records)} set(s):")
+    for record in records:
+        detail = (
+            f"query: {record['query']}"
+            if record["kind"] == "query"
+            else f"{record['n_declared']} declared experiment(s)"
+        )
+        click.echo(f"  {record['name']}  ({record['kind']}) {detail}")
+    click.echo("Run `smftools project show-set PROJECT_DIR NAME` to resolve one.")
+
+
+@project_group.command("show-set")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("name")
+def project_show_set_cmd(project_dir: Path, name):
+    """Show the experiments a named set resolves to, exactly as --set applies it."""
+    from .cli.project_cmd import project_show_set
+
+    try:
+        membership = project_show_set(project_dir, name)
+    except KeyError as exc:
+        raise click.ClickException(
+            f"no set {name!r} in project; `smftools project list-sets` shows the defined sets"
+        ) from exc
+    click.echo(f"Set '{membership.name}' ({membership.kind})")
+    if membership.query is not None:
+        click.echo(f"  query: {membership.query}")
+    _echo_set_membership(membership)
+
+
+@project_group.command("remove-set")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("name")
+def project_remove_set_cmd(project_dir: Path, name):
+    """Delete a named set. Registered experiments are never affected."""
+    from .cli.project_cmd import project_remove_set
+
+    try:
+        project_remove_set(project_dir, name)
+    except KeyError as exc:
+        raise click.ClickException(
+            f"no set {name!r} in project; `smftools project list-sets` shows the defined sets"
+        ) from exc
+    click.echo(f"Removed set '{name}'. No experiment registration was changed.")
+
+
+def _echo_set_membership(membership) -> None:
+    """Print resolved membership plus anything declared that does not resolve."""
+    if membership.resolved:
+        click.echo(f"  resolves to {len(membership.resolved)} experiment(s):")
+        for experiment_id in membership.resolved:
+            click.echo(f"    {experiment_id}")
+    else:
+        click.echo("  resolves to no experiments; --set would select nothing.")
+    if membership.missing:
+        click.echo(f"  not registered: {', '.join(membership.missing)}", err=True)
+    if membership.inactive:
+        click.echo(f"  inactive: {', '.join(membership.inactive)}", err=True)
+    if membership.duplicates:
+        click.echo(f"  listed more than once: {', '.join(membership.duplicates)}", err=True)
+
+
+##########################################
+
+
 ####### FASTQ export ###########
 @experiment_group.command("export-fastq")
 @click.argument("config_path", type=click.Path(exists=True, path_type=Path))

--- a/src/smftools/machine_learning/selection.py
+++ b/src/smftools/machine_learning/selection.py
@@ -33,7 +33,7 @@ from smftools.project.reference_registry import (
     REFERENCE_REGISTRY_FILENAME,
     ReferenceRegistry,
 )
-from smftools.project.registry import list_experiments, resolve_set
+from smftools.project.registry import list_experiments, resolve_set_membership
 
 from .plan import DatasetSpec, MLPlan, PhysicalChannelSource
 
@@ -334,16 +334,9 @@ def _project_metadata(
     by_id = {str(entry["id"]): entry for entry in entries}
     selected_ids = set(by_id)
     if set_name is not None:
-        saved = resolve_set(project_dir, set_name)
-        if saved.get("kind") == "list":
-            selected_ids &= {str(item) for item in saved.get("experiments", ())}
-        else:
-            from smftools.project.catalog import ProjectCatalog
-
-            result = ProjectCatalog.open(project_dir).query(
-                f"SELECT DISTINCT experiment FROM refs WHERE {saved['sql']}"
-            )
-            selected_ids &= set(result["experiment"].astype(str))
+        # Shared with the project catalog and `project show-set`, so an ML
+        # selection narrows to exactly the membership the CLI reports.
+        selected_ids &= set(resolve_set_membership(project_dir, set_name).resolved)
     if dataset.experiments.include:
         selected_ids &= set(dataset.experiments.include)
     selected_ids -= set(dataset.experiments.exclude)

--- a/src/smftools/project/catalog.py
+++ b/src/smftools/project/catalog.py
@@ -93,14 +93,11 @@ class ProjectCatalog:
         if experiments is not None:
             ids = {str(e) for e in experiments}
         if set_name is not None:
-            from .registry import resolve_set
+            from .registry import resolve_set_membership
 
-            saved = resolve_set(self.project_dir, set_name)
-            if saved["kind"] == "list":
-                set_ids = set(saved["experiments"])
-            else:
-                result = self.query(f"SELECT DISTINCT experiment FROM refs WHERE {saved['sql']}")
-                set_ids = set(result["experiment"].astype(str))
+            # Same resolution path as `project show-set`, so the membership a
+            # user is shown is the membership this filter applies.
+            set_ids = set(resolve_set_membership(self.project_dir, set_name, catalog=self).resolved)
             ids = set_ids if ids is None else (ids & set_ids)
         return ids
 

--- a/src/smftools/project/registry.py
+++ b/src/smftools/project/registry.py
@@ -15,6 +15,8 @@ harmonize references without opening matrices.
 from __future__ import annotations
 
 import json
+from collections import Counter
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -570,14 +572,81 @@ def resolve_experiment_spine(entry: dict, stage: str | None = None) -> tuple[str
     return None
 
 
+class SetMembershipError(ValueError):
+    """Raised when a named set's declared membership cannot be honored."""
+
+
+@dataclass(frozen=True)
+class SetMembership:
+    """One named set resolved to the experiments a ``--set`` consumer will select.
+
+    Fields:
+        name: The set name.
+        kind: ``"list"`` for an explicit membership, ``"query"`` for a saved query.
+        resolved: Sorted active experiment IDs the set selects. This is exactly
+            what ``--set`` narrows to, so displaying it cannot drift from what a
+            materialize or plan will use.
+        declared: What the set names, before dropping anything. Equal to
+            ``resolved`` for a query, whose results can only be active
+            experiments in the first place.
+        missing: Declared IDs that are not registered in this project at all.
+        inactive: Declared IDs registered but deactivated by ``project remove``.
+        duplicates: Declared IDs written more than once.
+        query: The saved SQL for a query set, otherwise ``None``.
+    """
+
+    name: str
+    kind: str
+    resolved: tuple[str, ...]
+    declared: tuple[str, ...]
+    missing: tuple[str, ...]
+    inactive: tuple[str, ...]
+    duplicates: tuple[str, ...]
+    query: str | None = None
+
+    @property
+    def is_clean(self) -> bool:
+        """Whether every declared experiment resolves to an active registration."""
+        return not (self.missing or self.inactive or self.duplicates)
+
+    def problem_summary(self) -> str:
+        """Return a one-line description of what does not resolve, or ``""``."""
+        parts = []
+        if self.missing:
+            parts.append(f"not registered: {', '.join(self.missing)}")
+        if self.inactive:
+            parts.append(f"inactive: {', '.join(self.inactive)}")
+        if self.duplicates:
+            parts.append(f"listed more than once: {', '.join(self.duplicates)}")
+        return "; ".join(parts)
+
+
 def add_set(
     project_dir: str | Path,
     name: str,
     *,
     experiments: list[str] | None = None,
     query: str | None = None,
+    validate: bool = False,
 ) -> None:
-    """Define a named set as an explicit experiment list OR a saved query."""
+    """Define a named set as an explicit experiment list OR a saved query.
+
+    Args:
+        project_dir: Project root holding ``registry.json``.
+        name: Set name, as later passed to ``--set``.
+        experiments: Explicit membership. Mutually exclusive with *query*.
+        query: Saved SQL predicate over the harmonized ``refs`` table. Mutually
+            exclusive with *experiments*.
+        validate: Reject a set that names an unregistered, deactivated, or
+            repeated experiment, or a query that does not resolve. Off by
+            default so existing API callers keep their behavior; the CLI turns
+            it on, since a set that silently selects fewer experiments than it
+            names is indistinguishable from a correct one at use time.
+
+    Raises:
+        ValueError: Neither or both of *experiments* and *query* were given.
+        SetMembershipError: *validate* is set and the membership does not resolve.
+    """
     if (experiments is None) == (query is None):
         raise ValueError("provide exactly one of experiments= or query=")
     registry = load_registry(project_dir)
@@ -586,6 +655,14 @@ def add_set(
         if experiments is not None
         else {"kind": "query", "sql": str(query)}
     )
+    if validate:
+        # Resolve against the pending definition so nothing is written when it
+        # does not hold, rather than saving first and reporting afterwards.
+        membership = _membership_from_definition(
+            project_dir, name, registry["sets"][name], registry
+        )
+        if not membership.is_clean:
+            raise SetMembershipError(f"set {name!r} {membership.problem_summary()}")
     save_registry(project_dir, registry)
 
 
@@ -595,3 +672,93 @@ def resolve_set(project_dir: str | Path, name: str) -> dict:
     if the_set is None:
         raise KeyError(f"no set '{name}' in project")
     return the_set
+
+
+def list_sets(project_dir: str | Path) -> dict[str, dict]:
+    """Return every named set definition, keyed by name."""
+    return dict(load_registry(project_dir).get("sets", {}))
+
+
+def remove_set(project_dir: str | Path, name: str) -> None:
+    """Delete a named set definition.
+
+    Sets are saved selections over the registry, not registered data, so unlike
+    :func:`remove_experiment` this is a real deletion rather than a status flip.
+    No experiment registration is touched.
+
+    Raises:
+        KeyError: No set by that name exists.
+    """
+    registry = load_registry(project_dir)
+    if name not in registry.get("sets", {}):
+        raise KeyError(f"no set '{name}' in project")
+    del registry["sets"][name]
+    save_registry(project_dir, registry)
+
+
+def _membership_from_definition(
+    project_dir: str | Path,
+    name: str,
+    definition: dict,
+    registry: dict,
+    *,
+    catalog=None,
+) -> SetMembership:
+    experiments = registry.get("experiments", {})
+    active = {exp_id for exp_id, entry in experiments.items() if entry.get("status") == "active"}
+    kind = str(definition.get("kind", ""))
+    query = None
+    if kind == "list":
+        declared = tuple(str(item) for item in definition.get("experiments", ()))
+    elif kind == "query":
+        query = str(definition.get("sql", ""))
+        if catalog is None:
+            from .catalog import ProjectCatalog
+
+            catalog = ProjectCatalog.open(project_dir)
+        # The harmonized `refs` table is built from active registrations only,
+        # so a query can never name a missing or deactivated experiment.
+        result = catalog.query(f"SELECT DISTINCT experiment FROM refs WHERE {query}")
+        declared = tuple(sorted({str(value) for value in result["experiment"]}))
+    else:
+        raise SetMembershipError(f"set {name!r} has unsupported kind {kind!r}")
+    counts = Counter(declared)
+    duplicates = tuple(sorted(item for item, count in counts.items() if count > 1))
+    unique = set(declared)
+    return SetMembership(
+        name=str(name),
+        kind=kind,
+        resolved=tuple(sorted(unique & active)),
+        declared=declared,
+        missing=tuple(sorted(unique - set(experiments))),
+        inactive=tuple(sorted((unique & set(experiments)) - active)),
+        duplicates=duplicates,
+        query=query,
+    )
+
+
+def resolve_set_membership(project_dir: str | Path, name: str, *, catalog=None) -> SetMembership:
+    """Resolve one named set to the active experiments a ``--set`` filter selects.
+
+    This is the single resolution path: the project catalog, the ML selection
+    layer, and ``project show-set`` all route through it, so what the CLI
+    displays is by construction what a materialize, plan, or embedding
+    selection will use.
+
+    Args:
+        project_dir: Project root holding ``registry.json``.
+        name: Set name.
+        catalog: Optional already-open :class:`~smftools.project.catalog.ProjectCatalog`,
+            used only for a query set. Opened on demand when omitted.
+
+    Returns:
+        The resolved membership, including anything declared that does not resolve.
+
+    Raises:
+        KeyError: No set by that name exists.
+    """
+    registry = load_registry(project_dir)
+    definition = registry.get("sets", {}).get(name)
+    if definition is None:
+        raise KeyError(f"no set '{name}' in project")
+    return _membership_from_definition(project_dir, name, definition, registry, catalog=catalog)

--- a/tests/unit/test_project_cli.py
+++ b/tests/unit/test_project_cli.py
@@ -480,3 +480,165 @@ def test_project_cli_registers_and_materializes_legacy_monolithic_file(tmp_path)
     combined, _ = safe_read_h5ad(out)
     assert combined.n_obs == 3
     assert set(combined.obs["experiment"]) == {"legacyExp"}
+
+
+def _project_with_two_experiments(tmp_path):
+    """Register two real single-reference experiments and return the project dir."""
+    uid = reference_uid(SEQUENCE, 12)
+    _make_raw_experiment(tmp_path / "expA", reference_strand="geneA_top", uid=uid, n=4)
+    _make_raw_experiment(tmp_path / "expB", reference_strand="geneA_top", uid=uid, n=4)
+    proj = tmp_path / "project"
+    runner = CliRunner()
+    assert runner.invoke(cli_entry.cli, ["project", "init", str(proj)]).exit_code == 0
+    for name in ("expA", "expB"):
+        result = runner.invoke(cli_entry.cli, ["project", "add", str(proj), str(tmp_path / name)])
+        assert result.exit_code == 0, result.output
+    return proj, uid, runner
+
+
+def test_set_commands_define_list_show_and_remove_without_python(tmp_path):
+    """The `--set` flag is only usable if sets can be managed from the CLI alone."""
+    proj, _uid, runner = _project_with_two_experiments(tmp_path)
+
+    r = runner.invoke(cli_entry.cli, ["project", "list-sets", str(proj)])
+    assert r.exit_code == 0, r.output
+    assert "No named sets defined" in r.output
+
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "add-set", str(proj), "cohort", "--experiment", "expA"],
+    )
+    assert r.exit_code == 0, r.output
+    assert "Defined set 'cohort' (list)." in r.output
+    assert "resolves to 1 experiment(s):" in r.output
+
+    r = runner.invoke(cli_entry.cli, ["project", "list-sets", str(proj)])
+    assert r.exit_code == 0, r.output
+    assert "cohort  (list) 1 declared experiment(s)" in r.output
+
+    r = runner.invoke(cli_entry.cli, ["project", "show-set", str(proj), "cohort"])
+    assert r.exit_code == 0, r.output
+    assert "expA" in r.output and "expB" not in r.output
+
+    r = runner.invoke(cli_entry.cli, ["project", "remove-set", str(proj), "cohort"])
+    assert r.exit_code == 0, r.output
+    assert "No experiment registration was changed." in r.output
+
+    # The set is gone; both experiments remain registered.
+    assert runner.invoke(cli_entry.cli, ["project", "show-set", str(proj), "cohort"]).exit_code == 1
+    r = runner.invoke(cli_entry.cli, ["project", "list", str(proj)])
+    assert "expA" in r.output and "expB" in r.output
+
+
+def test_add_set_rejects_an_unresolvable_member_unless_allowed(tmp_path):
+    """A typo in a set name must fail at definition, not silently narrow later."""
+    proj, _uid, runner = _project_with_two_experiments(tmp_path)
+
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "add-set", str(proj), "typo", "--experiment", "expA", "--experiment", "ghost"],
+    )
+    assert r.exit_code == 1
+    assert "not registered: ghost" in r.output
+    assert "--allow-unresolved" in r.output
+    # Nothing was written, so the next command does not see a half-accepted set.
+    assert (
+        "No named sets defined"
+        in runner.invoke(cli_entry.cli, ["project", "list-sets", str(proj)]).output
+    )
+
+    r = runner.invoke(
+        cli_entry.cli,
+        [
+            "project",
+            "add-set",
+            str(proj),
+            "typo",
+            "--experiment",
+            "expA",
+            "--experiment",
+            "ghost",
+            "--allow-unresolved",
+        ],
+    )
+    assert r.exit_code == 0, r.output
+    assert "not registered: ghost" in r.output
+
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "add-set", str(proj), "both", "--experiment", "expA", "--query", "x=1"],
+    )
+    assert r.exit_code == 1
+    assert "exactly one of --experiment or --query" in r.output
+
+
+def test_set_consumers_select_exactly_the_shown_membership(tmp_path):
+    """What `show-set` prints has to be what `--set` applies, including a query set."""
+    from smftools.project.catalog import ProjectCatalog
+    from smftools.project.registry import resolve_set_membership
+
+    proj, uid, runner = _project_with_two_experiments(tmp_path)
+    assert (
+        runner.invoke(
+            cli_entry.cli,
+            ["project", "add-set", str(proj), "cohort", "--experiment", "expB"],
+        ).exit_code
+        == 0
+    )
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "add-set", str(proj), "direct", "--query", "modality='direct'"],
+    )
+    assert r.exit_code == 0, r.output
+
+    catalog = ProjectCatalog.open(proj)
+    for name in ("cohort", "direct"):
+        shown = resolve_set_membership(proj, name).resolved
+        selected = catalog.select(canonical_reference=uid, set_name=name)
+        assert tuple(sorted(set(selected["experiment"]))) == shown, name
+
+    # A materialize through the same filter pools exactly those experiments.
+    out = tmp_path / "cohort.h5ad"
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "materialize", str(proj), uid, "-o", str(out), "--set", "cohort"],
+    )
+    assert r.exit_code == 0, r.output
+    combined, _ = safe_read_h5ad(out)
+    assert set(combined.obs["experiment"]) == {"expB"}
+
+
+def test_deactivated_experiment_drops_out_of_a_set_visibly(tmp_path):
+    """`project remove` narrows a set; the CLI has to show that, not hide it."""
+    proj, uid, runner = _project_with_two_experiments(tmp_path)
+    assert (
+        runner.invoke(
+            cli_entry.cli,
+            [
+                "project",
+                "add-set",
+                str(proj),
+                "cohort",
+                "--experiment",
+                "expA",
+                "--experiment",
+                "expB",
+            ],
+        ).exit_code
+        == 0
+    )
+    assert runner.invoke(cli_entry.cli, ["project", "remove", str(proj), "expB"]).exit_code == 0
+
+    r = runner.invoke(cli_entry.cli, ["project", "show-set", str(proj), "cohort"])
+    assert r.exit_code == 0, r.output
+    assert "resolves to 1 experiment(s):" in r.output
+    assert "inactive: expB" in r.output
+
+    out = tmp_path / "cohort.h5ad"
+    r = runner.invoke(
+        cli_entry.cli,
+        ["project", "materialize", str(proj), uid, "-o", str(out), "--set", "cohort"],
+    )
+    assert r.exit_code == 0, r.output
+    combined, _ = safe_read_h5ad(out)
+    assert set(combined.obs["experiment"]) == {"expA"}

--- a/tests/unit/test_project_registry.py
+++ b/tests/unit/test_project_registry.py
@@ -478,6 +478,82 @@ def test_sets_list_and_query(tmp_path):
         reg.add_set(proj, "bad", experiments=["a"], query="x")
 
 
+def _register_stub_experiments(project_dir, **statuses):
+    """Register experiments directly, for set tests that need no real spines."""
+    registry = reg.load_registry(project_dir)
+    for exp_id, status in statuses.items():
+        registry["experiments"][exp_id] = {
+            "path": ".",
+            "status": status,
+            "modality": "direct",
+            "references": {},
+            "n_reads": 1,
+            "date_added": "now",
+            "schema_version": reg.SCHEMA_VERSION,
+            "spines": {},
+            "catalogs": {},
+        }
+    reg.save_registry(project_dir, registry)
+
+
+def test_set_membership_separates_resolved_from_unresolvable_members(tmp_path):
+    """A set that names an unusable experiment must say so, not quietly shrink.
+
+    Nothing downstream can distinguish a set that selects two experiments on
+    purpose from one that named four and lost two to a typo or a deactivation,
+    so the resolution reports both halves.
+    """
+    proj = tmp_path / "p"
+    reg.init_project(proj)
+    _register_stub_experiments(proj, expA="active", expB="active", expOld="inactive")
+    reg.add_set(proj, "mixed", experiments=["expB", "expA", "expOld", "ghost", "expA"])
+
+    membership = reg.resolve_set_membership(proj, "mixed")
+
+    assert membership.kind == "list"
+    # Sorted, deduplicated, and restricted to active registrations.
+    assert membership.resolved == ("expA", "expB")
+    assert membership.declared == ("expB", "expA", "expOld", "ghost", "expA")
+    assert membership.missing == ("ghost",)
+    assert membership.inactive == ("expOld",)
+    assert membership.duplicates == ("expA",)
+    assert not membership.is_clean
+    assert "not registered: ghost" in membership.problem_summary()
+
+
+def test_validated_set_is_rejected_without_being_written(tmp_path):
+    """A rejected definition must not land in the registry as a half-accepted set."""
+    proj = tmp_path / "p"
+    reg.init_project(proj)
+    _register_stub_experiments(proj, expA="active")
+
+    with pytest.raises(reg.SetMembershipError, match="not registered: ghost"):
+        reg.add_set(proj, "typo", experiments=["expA", "ghost"], validate=True)
+
+    assert reg.list_sets(proj) == {}
+    # The same definition is still storable when the caller accepts it knowingly.
+    reg.add_set(proj, "typo", experiments=["expA", "ghost"])
+    assert reg.resolve_set_membership(proj, "typo").resolved == ("expA",)
+
+
+def test_removing_a_set_leaves_every_experiment_registered(tmp_path):
+    """Sets are saved selections; deleting one must not touch registered data."""
+    proj = tmp_path / "p"
+    reg.init_project(proj)
+    _register_stub_experiments(proj, expA="active", expB="active")
+    reg.add_set(proj, "cohort", experiments=["expA"], validate=True)
+    reg.add_set(proj, "other", experiments=["expB"], validate=True)
+
+    reg.remove_set(proj, "cohort")
+
+    assert sorted(reg.list_sets(proj)) == ["other"]
+    assert sorted(entry["id"] for entry in reg.list_experiments(proj)) == ["expA", "expB"]
+    with pytest.raises(KeyError):
+        reg.remove_set(proj, "cohort")
+    with pytest.raises(KeyError):
+        reg.resolve_set_membership(proj, "cohort")
+
+
 def test_reference_harmonization_same_sequence_different_names():
     experiments = [
         {"id": "A", "references": {"myGene_top": "uidX", "myGene_bottom": "uidX"}},


### PR DESCRIPTION
Every project command already accepted `--set NAME`, but a set could only be created by calling the Python registry API, and `project init` scaffolding even advertised a `project add-set` command that did not exist. PCLI-01 closes that: add-set, list-sets, show-set, and remove-set.

Definition is validated. Naming an experiment that is not registered, has been deactivated, or is repeated fails without writing anything, because a set that silently selects fewer experiments than it names is indistinguishable from a correct one at use time; --allow-unresolved covers the case where the set is written before the experiments it names are registered.

`--set` had two independent resolvers -- one in ProjectCatalog, one in the ML selection layer -- each dispatching on set kind and intersecting differently. Both now route through registry.resolve_set_membership, which show-set also uses, so the membership a user is shown is structurally the membership their materialize or plan applies rather than a claim that could drift. That is behavior-preserving: the harmonized reference table and ML selection were already restricted to active registrations, so dropping missing and inactive members during resolution changes nothing about what gets selected -- it only makes the drop visible.

remove-set is a real deletion, unlike `project remove`, which deactivates an experiment in the append-only registry: a set is a saved selection, not registered data. No experiment registration is touched.