### PR TITLE
feat: execute and validate shared project embeddings as a workflow pr…

### DIFF
--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -110,3 +110,9 @@ smftools project sample-analysis PROJECT_DIR CANONICAL_REFERENCE \
 
 smftools project validate PROJECT_DIR "${TASK_OUTPUT}" --json
 ```
+
+`smftools project embedding` completes the set of executable plan targets. It
+publishes the shared coordinate system as a project-scoped immutable generation
+and exports the coordinates task-locally. Extending an existing embedding loads
+this project's persisted estimator pickles, so it fails unless the run opts in
+with `--trust-local-models`; that decision is recorded in the result.

--- a/docs/source/tutorials/cli_usage.md
+++ b/docs/source/tutorials/cli_usage.md
@@ -375,6 +375,26 @@ canonical name even if experiments called it something different.
   `project validate PROJECT_DIR TASK_OUTPUT` checks the artifact and re-plans to detect a project
   that has moved on. A selection matching no cataloged partition fails with a structured result
   rather than writing an empty table.
+- `project embedding PROJECT_DIR CANONICAL_REFERENCE --output-root TASK_OUTPUT` executes the
+  `embedding` target, fitting or extending one shared cross-experiment coordinate system. The
+  durable product is an immutable, checksummed generation inside the project, selected by the
+  embedding's own current pointer; the task-local `embedding.parquet` exports per-molecule UMAP/PCA
+  coordinates and cluster assignments. The estimator pickles are never copied into the task output.
+  This is a different product from `export-latent`: experiment-local latent coordinates are fitted
+  per experiment/core and cannot be pooled, whereas this fits one space across the selection.
+  - An identical request against an unchanged project returns `compatible_skip` without loading any
+    model.
+  - Growing the selection (registering another experiment) transforms only the new molecules onto
+    the existing space, which requires loading this project's persisted PCA/UMAP estimators. Those
+    are pickle files, so the run fails with `EmbeddingTrustError` unless you pass
+    `--trust-local-models`. Pass it only for a project tree you trust; unpickling executes code from
+    those files.
+  - Removing molecules, or changing the feature values of ones already embedded, cannot be
+    reconciled incrementally and requires `--force-recompute`, which refits from scratch and retains
+    the prior generation.
+  - `--feature-kind`, `--layer`, `--start`, `--end`, `--leiden-resolution`, `--n-neighbors`,
+    `--min-reads`, and `--random-state` are all part of the embedding's identity, so changing any of
+    them selects a different generation rather than overwriting one.
 - `project export-latent PROJECT_DIR OUTPUT_DIR` exports one Zarr artifact per experiment/core
   latent coordinate owner plus a portable catalog and completion manifest. Filters include
   `--canonical-reference`, repeatable `--experiment`, `--molecule-uid`, and

--- a/src/smftools/cli/project_cmd.py
+++ b/src/smftools/cli/project_cmd.py
@@ -477,6 +477,122 @@ def project_sample_analysis(
     }
 
 
+EMBEDDING_EXPORT_SCHEMA_VERSION = 1
+
+
+def project_embedding(
+    project_dir: str | Path,
+    canonical_reference: str,
+    output_path: str | Path,
+    *,
+    set_name: str | None = None,
+    modality: str | None = None,
+    experiments=None,
+    stage: str | None = None,
+    layer: str | None = None,
+    start: int | None = None,
+    end: int | None = None,
+    feature_kind: str = "raw",
+    leiden_resolution: float = 0.5,
+    n_neighbors: int = 15,
+    min_reads: int = 10,
+    random_state: int = 42,
+    force_recompute: bool = False,
+    trust_local_models: bool = False,
+) -> dict:
+    """Fit or extend one shared project embedding and export its coordinates.
+
+    The durable product stays where it belongs: an immutable, checksummed
+    generation inside the project, selected by the embedding's own current
+    pointer. What lands in *output_path* is a portable table of the coordinates
+    and cluster assignments -- never the estimator pickles, which are
+    trusted-local runtime artifacts and must not be spread into task outputs by
+    a workflow that merely read them.
+
+    Args:
+        project_dir: Project root.
+        canonical_reference: Harmonized reference to embed.
+        output_path: Task-local parquet path for the exported coordinates.
+        set_name: Optional named set restricting the experiments.
+        modality: Optional modality restriction.
+        experiments: Optional explicit experiment IDs.
+        stage: Optional pipeline stage for spine resolution.
+        layer: Layer to embed; ``None`` uses ``X``.
+        start: Optional genomic window start.
+        end: Optional genomic window end.
+        feature_kind: ``"raw"`` or ``"acf"`` feature construction.
+        leiden_resolution: Leiden clustering resolution.
+        n_neighbors: Neighborhood size for UMAP and clustering.
+        min_reads: Minimum reads required to fit.
+        random_state: Deterministic seed.
+        force_recompute: Refit from scratch, retaining prior generations.
+        trust_local_models: Permit loading this project's persisted estimator
+            pickles, which incremental growth requires.
+
+    Returns:
+        A summary with the selected generation, fit kind, and molecule counts.
+    """
+    import numpy as np
+    import pandas as pd
+
+    from ..project.embedding_store import fit_or_extend_embedding
+
+    result = fit_or_extend_embedding(
+        project_dir,
+        canonical_reference,
+        set_name=set_name,
+        modality=modality,
+        experiments=experiments,
+        stage=stage,
+        layer=layer,
+        start=start,
+        end=end,
+        feature_kind=feature_kind,
+        leiden_resolution=leiden_resolution,
+        n_neighbors=n_neighbors,
+        min_reads=min_reads,
+        random_state=random_state,
+        force_recompute=force_recompute,
+        trust_local_models=trust_local_models,
+    )
+    obs_names = [str(name) for name in result["obs_names"]]
+    umap = np.asarray(result["X_umap"], dtype=np.float64)
+    pca = np.asarray(result["X_pca"], dtype=np.float64)
+    frame = pd.DataFrame({"molecule_uid": obs_names, "cluster": np.asarray(result["clusters"])})
+    for index in range(umap.shape[1]):
+        frame[f"umap_{index + 1}"] = umap[:, index]
+    for index in range(pca.shape[1]):
+        frame[f"pca_{index + 1}"] = pca[:, index]
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(output_path, index=False)
+    # Generation identity lives on the published manifest the store returns as
+    # `meta`, not on the coordinate payload.
+    meta = result.get("meta", {}) or {}
+    summary = {
+        "schema_version": EMBEDDING_EXPORT_SCHEMA_VERSION,
+        "canonical_reference": str(canonical_reference),
+        "generation_id": str(meta.get("generation_id", "")),
+        "fit_kind": str(meta.get("fit_kind", "")),
+        "prior_generation_id": meta.get("prior_generation_id"),
+        "n_molecules": int(len(obs_names)),
+        # From the published manifest rather than the in-memory fit result: the
+        # generation read back after publication does not carry the growth
+        # counters, so sourcing them there silently reports zero new molecules.
+        "n_new_molecules": int(meta.get("n_new_reads", 0) or 0),
+        "n_clusters": int(len(set(map(str, result["clusters"])))),
+        "feature_kind": str(feature_kind),
+    }
+    logger.info(
+        "Exported project embedding generation %s (%s fit, %d molecules) -> %s",
+        summary["generation_id"] or "unknown",
+        summary["fit_kind"] or "unknown",
+        summary["n_molecules"],
+        output_path,
+    )
+    return summary
+
+
 def project_sample_store_list(
     project_dir: str | Path, experiment_id: str | None = None
 ) -> list[dict]:

--- a/src/smftools/cli/workflow_contract.py
+++ b/src/smftools/cli/workflow_contract.py
@@ -1418,6 +1418,266 @@ def run_project_sample_analysis_workflow(
     return result_path
 
 
+def _embedding_request(
+    canonical_reference: str,
+    *,
+    output_name: str,
+    set_name: str | None,
+    modality: str | None,
+    experiments: tuple[str, ...],
+    stage: str | None,
+    start: int | None,
+    end: int | None,
+    layer: str | None,
+    feature_kind: str,
+    leiden_resolution: float,
+    n_neighbors: int,
+    min_reads: int,
+    random_state: int,
+) -> dict[str, Any]:
+    return {
+        "canonical_reference": str(canonical_reference),
+        "output_name": output_name,
+        "set_name": set_name,
+        "modality": modality,
+        "experiments": list(experiments) if experiments else None,
+        "stage": stage,
+        "start": start,
+        "end": end,
+        "layer": layer,
+        "feature_kind": str(feature_kind),
+        "leiden_resolution": float(leiden_resolution),
+        "n_neighbors": int(n_neighbors),
+        "min_reads": int(min_reads),
+        "random_state": int(random_state),
+    }
+
+
+def run_project_embedding_workflow(
+    project_dir: str | Path,
+    canonical_reference: str,
+    *,
+    output_root: str | Path,
+    output_name: str | None = None,
+    result_json: str | Path | None = None,
+    set_name: str | None = None,
+    modality: str | None = None,
+    experiments: tuple[str, ...] = (),
+    stage: str | None = None,
+    start: int | None = None,
+    end: int | None = None,
+    layer: str | None = None,
+    feature_kind: str = "raw",
+    leiden_resolution: float = 0.5,
+    n_neighbors: int = 15,
+    min_reads: int = 10,
+    random_state: int = 42,
+    force_recompute: bool = False,
+    trust_local_models: bool = False,
+    cpus: int | None = None,
+    memory_gb: float | None = None,
+    memory_percent: float | None = 60.0,
+) -> Path:
+    """Fit or extend a shared project embedding under the workflow contract.
+
+    The embedding generation itself is published inside the project, since a
+    shared coordinate system is a project-scoped product; the task-local root
+    receives the exported coordinates and the result contract. Task-local latent
+    coordinates are a different product entirely and are never pooled here.
+    """
+    from ..cli.project_cmd import EMBEDDING_EXPORT_SCHEMA_VERSION, project_embedding, project_plan
+
+    source_project = _local_path(project_dir, label="project")
+    run_root = _local_path(output_root, label="output root")
+    if run_root.is_relative_to(source_project):
+        raise WorkflowContractError(
+            "project workflow output root must be outside the source project directory"
+        )
+    run_root.mkdir(parents=True, exist_ok=True)
+    result_path = _result_path(run_root, result_json)
+    name = output_name or "embedding.parquet"
+    embedding_path = _require_within(
+        run_root / name,
+        run_root,
+        label="project embedding output",
+    )
+    reserved = (
+        result_path,
+        run_root / WORKFLOW_VERSIONS_FILENAME,
+        run_root / WORKFLOW_RUNTIME_DIRECTORY,
+    )
+    if any(
+        embedding_path == path
+        or embedding_path.is_relative_to(path)
+        or path.is_relative_to(embedding_path)
+        for path in reserved
+    ):
+        raise WorkflowContractError(
+            f"project output name overlaps workflow-owned control artifacts: {name!r}"
+        )
+    request = _embedding_request(
+        canonical_reference,
+        output_name=name,
+        set_name=set_name,
+        modality=modality,
+        experiments=experiments,
+        stage=stage,
+        start=start,
+        end=end,
+        layer=layer,
+        feature_kind=feature_kind,
+        leiden_resolution=leiden_resolution,
+        n_neighbors=n_neighbors,
+        min_reads=min_reads,
+        random_state=random_state,
+    )
+    started = perf_counter()
+    started_at = _now()
+    run_id = uuid4().hex
+    failure: dict[str, Any] | None = None
+    plan_payload: dict[str, Any] | None = None
+    versions_path: Path | None = None
+    resources: dict[str, Any] = {}
+    summary: dict[str, Any] | None = None
+    outcome = "failed"
+
+    with _exclusive_run(run_root):
+        try:
+            plan = project_plan(
+                source_project,
+                "embedding",
+                canonical_reference,
+                set_name=set_name,
+                modality=modality,
+                experiments=experiments,
+                stage=stage,
+                start=start,
+                end=end,
+            )
+            plan_payload = plan.to_dict()
+            resources = _project_resource_decision(
+                cpus=cpus,
+                memory_gb=memory_gb,
+                memory_percent=memory_percent,
+            )
+            versions_path, _ = _write_versions(
+                run_root,
+                tools=(),
+                cfg=SimpleNamespace(),
+                strict=False,
+            )
+            if not force_recompute and _project_output_is_compatible(
+                result_path,
+                run_root,
+                request=request,
+                plan=plan_payload,
+                command="project.embedding",
+                artifact_id="project:embedding",
+            ):
+                outcome = "compatible_skip"
+            else:
+                summary = project_embedding(
+                    source_project,
+                    canonical_reference,
+                    embedding_path,
+                    set_name=set_name,
+                    modality=modality,
+                    experiments=list(experiments) or None,
+                    stage=stage,
+                    layer=layer,
+                    start=start,
+                    end=end,
+                    feature_kind=feature_kind,
+                    leiden_resolution=leiden_resolution,
+                    n_neighbors=n_neighbors,
+                    min_reads=min_reads,
+                    random_state=random_state,
+                    force_recompute=force_recompute,
+                    trust_local_models=trust_local_models,
+                )
+                if not embedding_path.exists():
+                    raise WorkflowContractError(
+                        "project embedding returned without publishing its output"
+                    )
+                outcome = "success"
+        except Exception as exc:
+            failure = {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "stage": "project.embedding",
+            }
+        artifacts = []
+        if embedding_path.exists():
+            artifacts.append(
+                _relative_artifact(
+                    run_root,
+                    embedding_path,
+                    artifact_id="project:embedding",
+                    schema_version=EMBEDDING_EXPORT_SCHEMA_VERSION,
+                    checksum=_sha256(embedding_path),
+                )
+            )
+        if versions_path is not None and versions_path.is_file():
+            artifacts.append(
+                _relative_artifact(
+                    run_root,
+                    versions_path,
+                    artifact_id="workflow:versions",
+                    schema_version=WORKFLOW_VERSIONS_SCHEMA_VERSION,
+                    checksum=_sha256(versions_path),
+                )
+            )
+        payload: dict[str, Any] = {
+            "schema_version": WORKFLOW_RESULT_SCHEMA_VERSION,
+            "result_id": uuid4().hex,
+            "run_id": run_id,
+            "command": "project.embedding",
+            "target": "embedding",
+            "outcome": outcome,
+            "started_at": started_at,
+            "completed_at": _now(),
+            "timings": {"elapsed_seconds": perf_counter() - started},
+            "run_root": ".",
+            "output_root": ".",
+            "runtime_config": None,
+            "plan": plan_payload,
+            "post_plan": plan_payload,
+            "generation_ids": (
+                {"project.embedding": summary["generation_id"]}
+                if summary and summary.get("generation_id")
+                else {}
+            ),
+            "artifacts": artifacts,
+            "schemas": {"project:embedding": EMBEDDING_EXPORT_SCHEMA_VERSION},
+            "resources": resources,
+            "sources": {
+                "project": {
+                    "kind": "project_registry",
+                    "fingerprint": _project_plan_identity(plan_payload),
+                }
+            },
+            "strict": False,
+            "failure": failure,
+            "request": request,
+            "summary": summary,
+            # Recorded because it changes what the run is permitted to load: the
+            # growth path unpickles this project's estimator state.
+            "trust_local_models": bool(trust_local_models),
+        }
+        contract_issues = workflow_result_contract_issues(payload)
+        if contract_issues:
+            raise WorkflowContractError(
+                f"refusing to publish invalid workflow result: {contract_issues}"
+            )
+        atomic_write_json(result_path, payload)
+        if failure is not None:
+            raise WorkflowContractError(
+                f"project workflow failed; structured result written to {result_path}: "
+                f"{failure['type']}: {failure['message']}"
+            )
+    return result_path
+
+
 def _project_plan_identity(plan: Mapping[str, Any] | None) -> str | None:
     if not isinstance(plan, Mapping):
         return None
@@ -1608,16 +1868,21 @@ def validate_workflow_output(
                             "current project selection no longer matches the published result",
                         )
                     )
-    elif command == "project.sample-analysis":
+    elif command in {"project.sample-analysis", "project.embedding"}:
+        target, artifact_id = (
+            ("sample-analysis", "project:sample-analysis")
+            if command == "project.sample-analysis"
+            else ("embedding", "project:embedding")
+        )
         if not any(
-            artifact.get("artifact_id") == "project:sample-analysis"
+            artifact.get("artifact_id") == artifact_id
             for artifact in result.get("artifacts", [])
             if isinstance(artifact, Mapping)
         ):
             issues.append(
                 _validation_issue(
                     "project_output_missing",
-                    "project result does not declare its sample-analysis artifact",
+                    f"project result does not declare its {target} artifact",
                 )
             )
         if project_dir is not None:
@@ -1627,7 +1892,7 @@ def validate_workflow_output(
             try:
                 current = project_plan(
                     project_dir,
-                    "sample-analysis",
+                    target,
                     request["canonical_reference"],
                     set_name=request.get("set_name"),
                     modality=request.get("modality"),

--- a/src/smftools/cli_entry.py
+++ b/src/smftools/cli_entry.py
@@ -1090,6 +1090,141 @@ def project_sample_analysis_cmd(
     click.echo(path)
 
 
+@project_group.command("embedding")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.argument("canonical_reference")
+@click.option(
+    "--output-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    required=True,
+    help="Exclusive task-local root for every generated artifact.",
+)
+@click.option(
+    "--output-name",
+    default=None,
+    help="Coordinate table name inside OUTPUT_ROOT (default: embedding.parquet).",
+)
+@click.option(
+    "--result-json",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Result path inside OUTPUT_ROOT (default: workflow_result.json).",
+)
+@click.option("--set", "set_name", default=None, help="Restrict to a named experiment set.")
+@click.option("--modality", default=None, help="Restrict to a modality.")
+@click.option(
+    "--experiment",
+    "experiments",
+    multiple=True,
+    help="Restrict to an experiment ID; repeat for multiple experiments.",
+)
+@click.option("--stage", default=None, help="Select one experiment pipeline stage.")
+@click.option("--start", type=int, default=None, help="Genomic window start (with --end).")
+@click.option("--end", type=int, default=None, help="Genomic window end (with --start).")
+@click.option("--layer", default=None, help="Layer to embed (default: X).")
+@click.option(
+    "--feature-kind",
+    type=click.Choice(["raw", "acf"]),
+    default="raw",
+    show_default=True,
+    help="Feature construction for the shared space.",
+)
+@click.option(
+    "--leiden-resolution", type=float, default=0.5, show_default=True, help="Leiden resolution."
+)
+@click.option(
+    "--n-neighbors", type=int, default=15, show_default=True, help="UMAP/cluster neighborhood size."
+)
+@click.option(
+    "--min-reads", type=int, default=10, show_default=True, help="Minimum reads required to fit."
+)
+@click.option("--random-state", type=int, default=42, show_default=True, help="Deterministic seed.")
+@click.option(
+    "--force-recompute",
+    is_flag=True,
+    help="Refit from scratch. Required when molecules were removed or their features changed.",
+)
+@click.option(
+    "--trust-local-models",
+    is_flag=True,
+    help=(
+        "Permit loading this project's persisted PCA/UMAP estimator pickles, which "
+        "extending an existing embedding requires. Pass this only for a project tree "
+        "you trust; unpickling executes code from those files."
+    ),
+)
+@click.option("--cpus", type=click.IntRange(min=1), default=None, help="Task-local CPU ceiling.")
+@click.option(
+    "--memory-gb",
+    type=click.FloatRange(min=0.001),
+    default=None,
+    help="Task-local memory ceiling in GiB.",
+)
+@click.option(
+    "--max-memory-percent",
+    "memory_percent",
+    type=click.FloatRange(min=1, max=100),
+    default=60.0,
+    show_default=True,
+    help="Ceiling as a percentage of available memory.",
+)
+def project_embedding_cmd(
+    project_dir,
+    canonical_reference,
+    output_root,
+    output_name,
+    result_json,
+    set_name,
+    modality,
+    experiments,
+    stage,
+    start,
+    end,
+    layer,
+    feature_kind,
+    leiden_resolution,
+    n_neighbors,
+    min_reads,
+    random_state,
+    force_recompute,
+    trust_local_models,
+    cpus,
+    memory_gb,
+    memory_percent,
+):
+    """Fit or extend one shared project embedding, task-locally."""
+    from .cli.workflow_contract import WorkflowContractError, run_project_embedding_workflow
+
+    try:
+        path = run_project_embedding_workflow(
+            project_dir,
+            canonical_reference,
+            output_root=output_root,
+            output_name=output_name,
+            result_json=result_json,
+            set_name=set_name,
+            modality=modality,
+            experiments=experiments,
+            stage=stage,
+            start=start,
+            end=end,
+            layer=layer,
+            feature_kind=feature_kind,
+            leiden_resolution=leiden_resolution,
+            n_neighbors=n_neighbors,
+            min_reads=min_reads,
+            random_state=random_state,
+            force_recompute=force_recompute,
+            trust_local_models=trust_local_models,
+            cpus=cpus,
+            memory_gb=memory_gb,
+            memory_percent=memory_percent,
+        )
+    except WorkflowContractError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(path)
+
+
 @project_group.command("validate")
 @click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @click.argument("output_root", type=click.Path(exists=True, file_okay=False, path_type=Path))

--- a/tests/unit/test_project_cli.py
+++ b/tests/unit/test_project_cli.py
@@ -791,3 +791,120 @@ def test_sample_analysis_reports_an_empty_selection_as_a_structured_failure(tmp_
     result = json.loads((output / "workflow_result.json").read_text(encoding="utf-8"))
     assert result["outcome"] == "failed"
     assert "no per-sample-store partition" in result["failure"]["message"]
+
+
+def _embeddable_experiment(tmp_path, name, uid, *, sample, seed, n=30, npos=300):
+    """One experiment with enough reads and structure to fit a shared embedding."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    out_dir = tmp_path / name
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for i in range(n):
+        phase = int(rng.integers(0, 2))
+        rows.append(
+            {
+                "read_id": f"{name}_{sample}_r{i}",
+                "reference": "geneA",
+                "Reference_strand": "geneA_top",
+                "sample": sample,
+                "barcode": sample,
+                "strand": "top",
+                "mapping_direction": "fwd",
+                "reference_start": 0,
+                "cigar": f"{npos}M",
+                "aligned_length": npos,
+                "sequence": [i % 4 for _ in range(npos)],
+                "quality": [30] * npos,
+                "mismatch": [4] * npos,
+                "modification_signal": [float(((p // 15) + phase) % 2) for p in range(npos)],
+            }
+        )
+    write_raw_store(
+        pd.DataFrame(rows),
+        out_dir,
+        reference_lengths={"geneA_top": npos},
+        extra_uns={
+            "reference_uids": {"geneA_top": uid},
+            "modality": "direct",
+            "experiment": name,
+        },
+    )
+    return out_dir
+
+
+def test_embedding_cli_fits_skips_and_requires_trust_before_growing(tmp_path):
+    """Growth unpickles this project's estimators, so it needs an explicit decision."""
+    uid = reference_uid("A" * 300, 300)
+    _embeddable_experiment(tmp_path, "expA", uid, sample="bc01", seed=1)
+    _embeddable_experiment(tmp_path, "expB", uid, sample="bc02", seed=2)
+    proj = tmp_path / "project"
+    output = tmp_path / "embedding-out"
+    runner = CliRunner()
+    assert runner.invoke(cli_entry.cli, ["project", "init", str(proj)]).exit_code == 0
+    assert (
+        runner.invoke(
+            cli_entry.cli, ["project", "add", str(proj), str(tmp_path / "expA")]
+        ).exit_code
+        == 0
+    )
+
+    command = [
+        "project",
+        "embedding",
+        str(proj),
+        uid,
+        "--output-root",
+        str(output),
+        "--min-reads",
+        "5",
+        "--n-neighbors",
+        "5",
+    ]
+    r = runner.invoke(cli_entry.cli, command)
+    assert r.exit_code == 0, r.output
+    result = json.loads((output / "workflow_result.json").read_text(encoding="utf-8"))
+    assert result["command"] == "project.embedding"
+    assert result["summary"]["fit_kind"] == "full"
+    assert result["summary"]["n_molecules"] == 30
+    assert result["trust_local_models"] is False
+    table = pd.read_parquet(output / "embedding.parquet")
+    assert {"molecule_uid", "cluster", "umap_1", "umap_2"} <= set(table.columns)
+    assert len(table) == 30
+    # Estimator pickles are trusted-local project artifacts; exporting coordinates
+    # must not spread them into a task output other steps will consume.
+    assert not list(output.rglob("*.pkl"))
+
+    r = runner.invoke(cli_entry.cli, ["project", "validate", str(proj), str(output), "--json"])
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.output)["valid"] is True
+
+    assert runner.invoke(cli_entry.cli, command).exit_code == 0
+    assert (
+        json.loads((output / "workflow_result.json").read_text(encoding="utf-8"))["outcome"]
+        == "compatible_skip"
+    )
+
+    # Registering another experiment grows the selection, which needs the models.
+    assert (
+        runner.invoke(
+            cli_entry.cli, ["project", "add", str(proj), str(tmp_path / "expB")]
+        ).exit_code
+        == 0
+    )
+    r = runner.invoke(cli_entry.cli, command)
+    assert r.exit_code == 1
+    blocked = json.loads((output / "workflow_result.json").read_text(encoding="utf-8"))
+    assert blocked["outcome"] == "failed"
+    assert blocked["failure"]["type"] == "EmbeddingTrustError"
+
+    r = runner.invoke(cli_entry.cli, [*command, "--trust-local-models"])
+    assert r.exit_code == 0, r.output
+    grown = json.loads((output / "workflow_result.json").read_text(encoding="utf-8"))
+    assert grown["trust_local_models"] is True
+    assert grown["summary"]["fit_kind"] == "extended"
+    assert grown["summary"]["n_molecules"] == 60
+    assert grown["summary"]["n_new_molecules"] == 30
+    assert grown["summary"]["prior_generation_id"]
+    assert len(pd.read_parquet(output / "embedding.parquet")) == 60

--- a/tests/unit/test_workflow_contract.py
+++ b/tests/unit/test_workflow_contract.py
@@ -150,6 +150,22 @@ def _patch_project_execution(monkeypatch, *, token="source-a", failure=None):
         return {"schema_version": 1, "n_partitions": 2, "n_reads": 12, "partitions": []}
 
     monkeypatch.setattr("smftools.cli.project_cmd.project_sample_analysis", sample_analysis)
+
+    def embedding(_project, _reference, output, **kwargs):
+        if failure is not None:
+            raise failure
+        output = Path(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"embedding")
+        return {
+            "schema_version": 1,
+            "generation_id": "generation-embed",
+            "fit_kind": "extended" if kwargs.get("trust_local_models") else "full",
+            "n_molecules": 30,
+            "n_new_molecules": 10 if kwargs.get("trust_local_models") else 0,
+        }
+
+    monkeypatch.setattr("smftools.cli.project_cmd.project_embedding", embedding)
     monkeypatch.setattr(
         workflow_contract,
         "_project_resource_decision",
@@ -832,3 +848,92 @@ def test_one_project_product_never_satisfies_another_in_the_same_root(tmp_path, 
     assert result["command"] == "project.sample-analysis"
     assert result["outcome"] == "success"
     assert (output / "sample_analysis.parquet").is_file()
+
+
+def test_project_embedding_workflow_success_skip_and_validation(tmp_path, monkeypatch):
+    """The `embedding` plan target needs a matching executable and validation path."""
+    project = tmp_path / "project"
+    project.mkdir()
+    output = tmp_path / "embedding-output"
+    _patch_project_execution(monkeypatch)
+
+    first = workflow_contract.run_project_embedding_workflow(
+        project,
+        "uid-ref",
+        output_root=output,
+    )
+    result = json.loads(first.read_text(encoding="utf-8"))
+    assert result["command"] == "project.embedding"
+    assert result["target"] == "embedding"
+    assert result["outcome"] == "success"
+    assert result["artifacts"][0]["artifact_id"] == "project:embedding"
+    # The shared coordinate system is a project-scoped generation; the result
+    # names it so a task output can be traced back to it.
+    assert result["generation_ids"] == {"project.embedding": "generation-embed"}
+    assert result["trust_local_models"] is False
+
+    second = workflow_contract.run_project_embedding_workflow(
+        project,
+        "uid-ref",
+        output_root=output,
+    )
+    assert json.loads(second.read_text(encoding="utf-8"))["outcome"] == "compatible_skip"
+    assert workflow_contract.validate_workflow_output(output, project_dir=project)["valid"]
+
+    _patch_project_execution(monkeypatch, token="source-b")
+    validation = workflow_contract.validate_workflow_output(output, project_dir=project)
+    assert validation["valid"] is False
+    assert "project_source_stale" in {issue["code"] for issue in validation["issues"]}
+
+
+def test_project_embedding_records_the_trust_decision_it_ran_under(tmp_path, monkeypatch):
+    """Unpickling this project's estimators is a decision, so the result records it."""
+    project = tmp_path / "project"
+    project.mkdir()
+    output = tmp_path / "embedding-output"
+    _patch_project_execution(monkeypatch)
+
+    path = workflow_contract.run_project_embedding_workflow(
+        project,
+        "uid-ref",
+        output_root=output,
+        trust_local_models=True,
+    )
+
+    result = json.loads(path.read_text(encoding="utf-8"))
+    assert result["trust_local_models"] is True
+    assert result["summary"]["fit_kind"] == "extended"
+    assert result["summary"]["n_new_molecules"] == 10
+
+
+def test_project_embedding_failure_writes_structured_result(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    output = tmp_path / "embedding-output"
+    _patch_project_execution(monkeypatch, failure=RuntimeError("trust required"))
+
+    with pytest.raises(workflow_contract.WorkflowContractError, match="trust required"):
+        workflow_contract.run_project_embedding_workflow(project, "uid-ref", output_root=output)
+
+    result = json.loads(
+        (output / workflow_contract.WORKFLOW_RESULT_FILENAME).read_text(encoding="utf-8")
+    )
+    assert result["outcome"] == "failed"
+    assert result["command"] == "project.embedding"
+    assert result["failure"]["stage"] == "project.embedding"
+
+
+def test_no_project_product_skips_against_another_in_one_root(tmp_path, monkeypatch):
+    """Three products, one output root: each must run on its own terms."""
+    project = tmp_path / "project"
+    project.mkdir()
+    output = tmp_path / "shared-output"
+    _patch_project_execution(monkeypatch)
+
+    workflow_contract.run_project_materialization_workflow(project, "uid-ref", output_root=output)
+    workflow_contract.run_project_sample_analysis_workflow(project, "uid-ref", output_root=output)
+    path = workflow_contract.run_project_embedding_workflow(project, "uid-ref", output_root=output)
+
+    assert json.loads(path.read_text(encoding="utf-8"))["outcome"] == "success"
+    for name in ("materialized.h5ad.gz", "sample_analysis.parquet", "embedding.parquet"):
+        assert (output / name).exists(), name


### PR DESCRIPTION
…oduct

PCLI-03 gives the `embedding` plan target a matching executable and validation path, completing the set of plan targets that can actually be run. Same contract as the other project products -- plan, run, compatible skip, structured failure, validation, source-staleness detection -- with its own command name and artifact ID so none of the three can be skipped against another in a shared output root.

The trust boundary is explicit at the CLI, which is the point of the item. Extending an existing embedding transforms new molecules onto the existing space by loading this project's persisted PCA/UMAP estimators, and those are pickle files; without --trust-local-models the run fails with EmbeddingTrustError rather than quietly unpickling. The decision is recorded in the result, so a consumer can tell which runs loaded local model state. Exact cache hits still load no model at all.

The durable product stays a project-scoped immutable generation -- a shared coordinate system belongs to the project, not to one task -- and the task-local export carries coordinates and cluster assignments only. The estimator pickles are deliberately not copied into the task output; spreading trusted-local artifacts into outputs other steps consume would defeat the boundary above. Task-local latent coordinates remain a separate product and are never pooled here.

Growth counters come from the published manifest rather than the in-memory fit result, which does not survive the read-back after publication and would have reported every extension as adding zero molecules.