### PR TITLE
chore: point acceptance catalogs at the current plan locations

### DIFF
--- a/tests/acceptance/input_alignment_criteria.json
+++ b/tests/acceptance/input_alignment_criteria.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source": "dev/in-progress/input_ingestion_alignment_audit.md#test-and-acceptance-gaps",
+  "source": "dev/completed/input_ingestion_alignment_audit.md#test-and-acceptance-gaps",
   "criteria": [
     {"id": "finding.iar_c1", "title": "A discovered BAM directory is passed downstream as though it were one BAM", "status": "automated", "evidence": ["tests/unit/config/test_input_contract.py::test_bam_directory_fails_before_output_directory_creation", "tests/unit/informatics/test_input_manifest.py::test_multiple_alignment_paths_require_explicit_manifest", "tests/e2e/cli/test_load_adata.py::test_partitioned_existing_bams_produce_one_raw_generation"]},
     {"id": "finding.iar_c2", "title": "Paired mates are neither one molecule nor compatible with unique row identity", "status": "automated", "evidence": ["tests/unit/informatics/test_raw_store.py::test_paired_segments_share_one_molecule_and_materialize_losslessly", "tests/unit/informatics/test_molecule_identity.py::test_segment_identity_is_unique_within_shared_template_and_across_experiments", "tests/e2e/cli/test_load_adata.py::test_paired_illumina_overlap_becomes_one_consensus_molecule"]},

--- a/tests/acceptance/ml_scale_thresholds.json
+++ b/tests/acceptance/ml_scale_thresholds.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "work_package": "ML-700",
-  "source": "dev/in-progress/ml700_benchmark_plan.md",
+  "source": "dev/completed/ml700_benchmark_plan.md",
   "purpose": "Committed limits and regression thresholds for the ML data plane. ML-701 writes user-facing prose from this file; it is the machine-readable half of ML-700's published limits.",
   "baseline_environment": {
     "note": "Baselines were captured on a developer laptop. CI must compare ratios and structure, never absolute byte counts or wall times, because hardware differs.",

--- a/tests/acceptance/partitioned_pipeline_criteria.json
+++ b/tests/acceptance/partitioned_pipeline_criteria.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source": "dev/experiment_project_partitioned_pipeline_audit.md#proposed-acceptance-criteria",
+  "source": "dev/completed/experiment_project_partitioned_pipeline_audit.md#proposed-acceptance-criteria",
   "criteria": [
     {"id": "correctness.full_modality_mode_matrix", "status": "deferred", "evidence": ["tests/unit/test_partitioned_pipeline_fixture.py::test_acceptance_fixture_covers_modality_mode_matrix_and_multiple_chunks"], "owner": "smftools maintainers", "reason": "Synthetic raw-store coverage is automated; fresh external-tool experiment full runs for the three protected real datasets require the local validation program."},
     {"id": "correctness.genome_bed_and_legacy_modes", "status": "automated", "evidence": ["tests/unit/config/test_LoadExperimentConfig.py::test_spatial_regions_bed_is_not_promoted_to_new_scopes", "tests/unit/informatics/test_analysis_region_plan.py::test_partitioned_stages_share_core_plan_and_provenance"]},

--- a/tests/acceptance/project_cli_criteria.json
+++ b/tests/acceptance/project_cli_criteria.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source": "dev/in-progress/input_ingestion_alignment_implementation_plan.md#pcli-04--project-analysis-acceptance",
+  "source": "dev/completed/input_ingestion_alignment_implementation_plan.md#pcli-04--project-analysis-acceptance",
   "criteria": [
     {"id": "finding.iar_m6", "title": "Named sets and planned analysis targets lacked CLI execution surfaces", "status": "automated", "evidence": ["tests/unit/test_project_cli.py::test_set_commands_define_list_show_and_remove_without_python", "tests/unit/test_project_cli.py::test_sample_analysis_cli_runs_validates_and_skips", "tests/unit/test_project_cli.py::test_embedding_cli_fits_skips_and_requires_trust_before_growing"]},
     {"id": "item.pcli_01", "title": "Named set add/list/show/remove commands", "status": "automated", "evidence": ["tests/unit/test_project_cli.py::test_set_commands_define_list_show_and_remove_without_python", "tests/unit/test_project_cli.py::test_add_set_rejects_an_unresolvable_member_unless_allowed", "tests/unit/test_project_registry.py::test_set_membership_separates_resolved_from_unresolvable_members", "tests/unit/test_project_registry.py::test_removing_a_set_leaves_every_experiment_registered"]},


### PR DESCRIPTION
Every catalog's `source` field named a path that no longer exists. Three programs finished and their audits/plans were re-filed under dev/completed/; one predates the status-folder layout entirely. A pointer nobody can follow is worse than none, since it reads as if the source were still where it says.

All four now name dev/completed/. The anchors were checked against the current headings rather than assumed: "## Test and acceptance gaps", "### PCLI-04 — project analysis acceptance", and "## Proposed acceptance criteria" all still exist.

No validator asserts these paths resolve, deliberately: dev/ is gitignored and per-worktree, so such a check would pass locally and fail in CI, and would fail for a contributor who simply has no dev/ tree.