### PR TITLE
release: 2.20.0

### DIFF
--- a/docs/source/release-notes/2.20.0.md
+++ b/docs/source/release-notes/2.20.0.md
@@ -1,0 +1,151 @@
+(v2.20.0)=
+
+2.20.0 2026-08-13
+Version 2.20.0 rebuilds how an experiment gets in: input is now a declared, content-addressed
+manifest rather than a directory scan, raw output is published as an immutable generation that can
+be restarted, relocated, and grown, alignment is an adapter contract covering minimap2, Dorado,
+BWA-MEM2, and Bowtie2 as well as existing aligned BAM/CRAM, paired Illumina mates become one
+molecule with a real consensus, and an experiment can be exported and re-ingested with its
+capabilities either preserved or explicitly declared lost. It also completes the project analysis
+CLI, so every target `project plan` advertises can be executed and validated.
+
+## Input is a declared contract
+
+Input resolution is one deterministic path. A file, a directory, or a user manifest all resolve to
+the same canonical schema-1 manifest, and the resolved identity is content-addressed rather than
+path-based, so changed bytes at an unchanged path are a different source.
+
+- Mixed-type directories fail before any output directory is created, listing the conflicting types
+  instead of silently picking one by priority.
+- A discovered BAM directory is no longer treated as a single BAM; multiple alignments require an
+  explicit manifest declaring each partition.
+- SAM remains unsupported and says so; CRAM is supported with `alignment_mode: existing` and is
+  validated against its exact reference.
+- Common Illumina and CASAVA filenames pair correctly, and an ambiguous pattern demands explicit
+  metadata rather than guessing.
+- Barcode and sample identity resolve through one precedence contract, published as a sidecar, with
+  the authority that supplied each label recorded.
+
+## Raw output is an immutable generation
+
+The raw stage publishes a checksummed, self-describing generation selected by an atomic pointer.
+
+- An identical request is a restart. A pure addition processes only the added sources and hardlinks
+  unchanged shards from the selected generation; anything else is a full recompute.
+- A run killed mid-stage is resumable. The next attempt supersedes the abandoned one and reuses the
+  retained complete generation, instead of failing permanently on a stage record still marked
+  `running`.
+- Immutability is detected, not enforced by permissions: every artifact carries a checksum, and
+  published files deliberately keep their write bit so a container running as an arbitrary,
+  non-owning UID can still manage the tree.
+- Pointers are relative throughout, so a finished output validates after being moved to another
+  path — including read-only, under a different user.
+
+## Alignment is an adapter contract
+
+Aligners are selected from a registry instead of being hard-coded, and each run publishes an
+alignment manifest recording the adapter, its normalized argv, tool version, and reference bundle.
+
+- minimap2, Dorado, BWA-MEM2, and Bowtie2 are supported; an unknown aligner fails during config
+  loading rather than deep inside the run.
+- `alignment_mode: existing` ingests an already-aligned BAM or CRAM without realigning it, after
+  validating reference names and lengths, sort order, pair flags, and — for direct modification —
+  the presence of MM/ML.
+- Multiple alignment sources can be ingested as namespaced partitions of one raw generation.
+
+## Paired reads are one molecule
+
+The raw store separates molecules from the physical segments that evidence them, so two mates share
+one molecule row without colliding on read identity.
+
+- Overlapping mates produce a deterministic consensus, with conflicts marked and base quality
+  breaking ties.
+- Non-overlapping mates keep the uncovered gap explicit rather than inventing signal across it.
+- Discordant pairs and singletons are handled explicitly instead of being silently merged.
+
+## Round-trip exports declare what they cost
+
+`export-bundle` writes a versioned, checksummed bundle in one of two kinds, and re-ingestion states
+plainly what each preserves.
+
+- `sequence_only` (FASTQ) records the capabilities it drops — BAM tags, alignment, read groups,
+  MM/ML — and cannot satisfy a direct-modification experiment.
+- `lossless_bam` carries the owned alignment forward: re-ingested with `alignment_mode: existing`,
+  no aligner runs, coordinates match the exporting generation exactly, and BC/RG/MM/ML survive.
+- Both relocate as a unit and are validated by checksum on read.
+
+## The project CLI can run what it plans
+
+`project plan` has long advertised targets with no way to execute them. All of them now execute and
+validate through the same result contract.
+
+- Named experiment sets are managed from the CLI (`add-set`, `list-sets`, `show-set`, `remove-set`).
+  Membership is validated when defined, and `show-set` resolves through the same code path `--set`
+  applies, so what is displayed is what a run selects.
+- `project sample-analysis` and `project embedding` execute the sample-analysis and embedding
+  targets task-locally, with compatible skip, structured failure, validation, and source-staleness
+  detection.
+- `project run --target` dispatches to any of the three products, defaulting to materialization so
+  existing invocations are unchanged. Options belonging to another target are rejected rather than
+  ignored.
+- Extending a shared embedding loads persisted estimator pickles, so it requires an explicit
+  `--trust-local-models`, and the decision is recorded in the result. Exact cache hits load no
+  model at all.
+
+## Defects found by exercising these paths
+
+Each of these was reproduced against a real run before being fixed, and carries a regression test.
+
+- A stage record left `running` by a killed process made every later invocation fail with an
+  unactionable transition error, recoverable only by hand-editing the manifest.
+- Empty external-tool output was cached and reused as a valid intermediate.
+- `project run --experiment` published a request naming a subset while pooling every experiment.
+- A per-sample partition with no analyzable read crashed the whole analysis on a NumPy index dtype
+  instead of contributing no rows.
+- Appended `uns` string lists lost their list semantics, and appended signal columns were not
+  unioned across generations.
+- Bundle provenance read a field the exporters never wrote, so every bundle reported no source
+  generation.
+- `statsmodels` was imported but declared in no extra, so relative-risk analysis failed on a
+  documented "everything" install — and its one test had been skipping rather than running.
+- Two experiment ids could share one experiment identity, which would make their molecules
+  indistinguishable project-wide.
+
+## Acceptance is recorded, not asserted
+
+`tests/acceptance/input_alignment_criteria.json` and `tests/acceptance/project_cli_criteria.json`
+map every audit finding, implementation item, and required property to the test that covers it, or
+to an owned deferment. A unit test resolves each cited test back to a real symbol, so a renamed or
+deleted test fails the suite rather than quietly leaving a false claim behind. One finding is
+recorded as withdrawn, with the reasoning, so a disproved conclusion is not rediscovered and
+"fixed" again.
+
+## Behavior changes
+
+No public API was removed. Three behaviors changed in ways worth knowing:
+
+- Registering two different experiment ids that carry the same experiment identity is now refused.
+  This normally means the same run is being registered twice under different ids.
+- `project run --experiment` now restricts the materialized output, where it previously affected
+  only the published plan.
+- A stage left in `planned` or `running` no longer blocks the next attempt.
+
+Raw generations move to schema 2 for the molecule/segment split; schema 1 generations remain
+readable and valid. The canonical input manifest and export bundles introduce schema 1.
+
+## Documentation
+
+The lifecycle, container, CLI, and configuration pages cover the input manifest, alignment modes and
+aligners, immutable generations and restart, relocation under a foreign UID, the two bundle kinds
+and what re-ingesting each preserves, named sets, and the project plan-target table mapping every
+target to its execution and validation path.
+
+## Known limitations
+
+- The basecalling end-to-end profiles skip when Dorado, its model directory, or modkit is absent.
+  They are covered locally, not in CI.
+- The `selection` plan target has no artifact of its own and remains planning-only by design.
+- A legacy raw layout is migrated in place only when its recorded stage is lifecycle-compatible;
+  otherwise it is recomputed from the declared inputs, which must still be reachable.
+- The duplicate-identity refusal applies at registration. A registry that already contains a
+  collision is not repaired automatically.

--- a/docs/source/release-notes/index.md
+++ b/docs/source/release-notes/index.md
@@ -2,6 +2,11 @@
 
 # Release notes
 
+### Version 2.20.0
+
+```{include} /release-notes/2.20.0.md
+```
+
 ### Version 2.19.0
 
 ```{include} /release-notes/2.19.0.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+# hatchling 1.32 defaults to Metadata-Version 2.5, which twine 6.2 still rejects
+# (it monkeypatches packaging's allowed list to stop at 2.4), so `twine check`
+# fails and an upload would be refused. Pinned below that until the packaging
+# tooling catches up.
+requires = ["hatchling<1.32", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]

--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.20.0.dev0"
+__version__ = "2.20.0"


### PR DESCRIPTION
Input ingestion, alignment, and round-trip (IAR-01..15) plus the project analysis CLI (PCLI-01..04): 30 merged PRs since v2.19.0. Input is a declared, content-addressed manifest; raw output is an immutable, restartable, relocatable generation; alignment is an adapter contract spanning minimap2, Dorado, BWA-MEM2, Bowtie2, and existing aligned BAM/CRAM; paired mates become one molecule with a real consensus; experiments export and re-ingest with their capabilities either preserved or declared lost; and every project plan target now has an executor and a validation path.

Also pins the build backend below hatchling 1.32. That release defaults to Metadata-Version 2.5, which twine 6.2 rejects -- it monkeypatches packaging's allowed list to stop at 2.4, even though the installed packaging accepts 2.5 -- so `twine check` failed on both artifacts and an upload would likely be refused. Bisected across hatchling 1.27 through 1.32 to find where the default changed; with the pin, both artifacts build and pass.

Verification at this commit: 1,821 unit (8 skipped, 7 xfailed), 106 smoke, Ruff check/format, warning-strict Sphinx build with the new notes rendering, and `python -m build` + `twine check dist/*` passing. The wheel installs into a clean venv and reports 2.20.0 from both the package and the CLI.