### PR TITLE
chore: start 2.21.0 development

### DIFF
--- a/src/smftools/_version.py
+++ b/src/smftools/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.20.0"
+__version__ = "2.21.0.dev0"


### PR DESCRIPTION
Opens the next cycle after the 2.20.0 release, matching the convention from `chore: start 2.20.0 development`: main carries a .devN suffix between releases so its version string is never mistaken for a shipped one.