### PR TITLE
feat: list published immutable generations read-only

### DIFF
--- a/src/smftools/cli/generations.py
+++ b/src/smftools/cli/generations.py
@@ -1,0 +1,128 @@
+"""CLI rendering for read-only generation inventories.
+
+Presentation only; discovery lives in
+:mod:`smftools.informatics.generation_listing`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..informatics.generation_listing import (
+    STATE_OK,
+    GenerationRecord,
+    list_experiment_generations,
+    list_project_generations,
+)
+
+_COLUMNS = ("", "KIND", "GENERATION", "STATE", "MODIFIED", "ARTIFACTS", "SIZE", "CONTAINER")
+
+
+def _human_bytes(value: int | None) -> str:
+    if value is None:
+        return "-"
+    size = float(value)
+    for unit in ("B", "K", "M", "G", "T"):
+        if size < 1024 or unit == "T":
+            return f"{size:.0f}{unit}" if unit == "B" else f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{size:.1f}T"
+
+
+def _short_timestamp(record: GenerationRecord) -> str:
+    stamp = record.created_at or record.modified_at
+    return stamp[:19] if stamp else "-"
+
+
+def _rows(records: Iterable[GenerationRecord]) -> list[tuple[str, ...]]:
+    rows: list[tuple[str, ...]] = []
+    for record in records:
+        rows.append(
+            (
+                "*" if record.is_current else " ",
+                record.kind,
+                record.generation_id,
+                record.state,
+                _short_timestamp(record),
+                "-" if record.artifact_count is None else str(record.artifact_count),
+                _human_bytes(record.size_bytes),
+                record.container,
+            )
+        )
+    return rows
+
+
+def render_table(records: list[GenerationRecord]) -> str:
+    """Render an aligned table plus a footer for any defects found."""
+    if not records:
+        return "No published generations found."
+
+    rows = [_COLUMNS] + _rows(records)
+    widths = [max(len(row[i]) for row in rows) for i in range(len(_COLUMNS))]
+    lines = [
+        "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)).rstrip() for row in rows
+    ]
+
+    flagged = [record for record in records if record.issues]
+    if flagged:
+        lines.append("")
+        lines.append(f"{len(flagged)} generation(s) with issues:")
+        for record in flagged:
+            for issue in record.issues:
+                lines.append(f"  {record.kind}/{record.generation_id}: {issue}")
+
+    current = sum(1 for record in records if record.is_current)
+    healthy = sum(1 for record in records if record.state == STATE_OK)
+    lines.append("")
+    lines.append(
+        f"{len(records)} generation(s); {current} current, "
+        f"{healthy} readable, {len(records) - healthy} unreadable or missing."
+    )
+    return "\n".join(lines)
+
+
+def render_json(records: list[GenerationRecord]) -> str:
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "generations": [record.to_dict() for record in records],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), indent=2)
+
+
+def experiment_generations(
+    output_root: str | Path,
+    *,
+    include_size: bool = False,
+) -> list[GenerationRecord]:
+    """Inventory one experiment output root."""
+    return list_experiment_generations(output_root, include_size=include_size)
+
+
+def project_generations(
+    project_dir: str | Path,
+    *,
+    include_size: bool = False,
+    include_experiments: bool = True,
+) -> list[GenerationRecord]:
+    """Inventory project-owned generations, optionally fanning out to experiments.
+
+    An experiment whose registered path is unreachable (an unmounted volume, a
+    moved tree) is skipped rather than raising: a partial inventory is the
+    useful answer, and the missing rows are visible by comparison with
+    ``project list``.
+    """
+    records = list_project_generations(project_dir, include_size=include_size)
+    if not include_experiments:
+        return records
+
+    from .project_cmd import project_list
+
+    experiments, _ = project_list(project_dir)
+    for entry in experiments:
+        path = Path(str(entry.get("path", "")))
+        if not path.is_dir():
+            continue
+        records.extend(list_experiment_generations(path, include_size=include_size))
+    return records

--- a/src/smftools/cli_entry.py
+++ b/src/smftools/cli_entry.py
@@ -326,6 +326,23 @@ def experiment_validate(output_root, result_json, as_json):
         raise click.exceptions.Exit(1)
 
 
+@experiment_group.command("generations")
+@click.argument("output_root", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--size",
+    "include_size",
+    is_flag=True,
+    help="Total each generation's bytes on disk (slower on large stores).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the stable machine-readable schema.")
+def experiment_generations_cmd(output_root, include_size, as_json):
+    """List published immutable generations for one experiment, without writing."""
+    from .cli.generations import experiment_generations, render_json, render_table
+
+    records = experiment_generations(output_root, include_size=include_size)
+    click.echo(render_json(records) if as_json else render_table(records))
+
+
 ##########################################
 
 
@@ -819,6 +836,32 @@ def project_list_cmd(project_dir: Path):
     if not references.empty:
         n_canon = references["canonical_reference"].nunique()
         click.echo(f"{n_canon} canonical reference(s) across the project.")
+
+
+@project_group.command("generations")
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--size",
+    "include_size",
+    is_flag=True,
+    help="Total each generation's bytes on disk (slower on large stores).",
+)
+@click.option(
+    "--project-only",
+    is_flag=True,
+    help="List only project-owned generations, skipping registered experiments.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the stable machine-readable schema.")
+def project_generations_cmd(project_dir: Path, include_size, project_only, as_json):
+    """List published immutable generations across a project, without writing."""
+    from .cli.generations import project_generations, render_json, render_table
+
+    records = project_generations(
+        project_dir,
+        include_size=include_size,
+        include_experiments=not project_only,
+    )
+    click.echo(render_json(records) if as_json else render_table(records))
 
 
 @project_group.command("plan")

--- a/src/smftools/informatics/generation_listing.py
+++ b/src/smftools/informatics/generation_listing.py
@@ -1,0 +1,351 @@
+"""Read-only enumeration of published immutable generations.
+
+Four subsystems publish immutable generations today, each with its own
+publisher/validator pair:
+
+- raw (:mod:`smftools.informatics.raw_generation`)
+- preprocess (:mod:`smftools.preprocessing.preprocess_generation`)
+- latent (:mod:`smftools.tools.partitioned_latent`)
+- project embeddings (:mod:`smftools.project.embedding_store`)
+
+They converged independently on the same on-disk vocabulary -- a
+``generations/<generation_id>/generation_manifest.json`` directory beside an
+atomically-published ``current.json`` selecting the one generation readers may
+consume -- and differ only in manifest payload and in whether the pointer
+carries ``manifest_sha256``. This module reads that shared vocabulary.
+
+It deliberately does **not** call the per-kind ``resolve_current_*`` validators.
+Those raise on the first defect, which is correct for a reader about to consume
+a generation and wrong for an inventory tool: listing is what you reach for when
+something is *already* broken, so every defect is reported as a record field
+rather than an exception. Nothing here writes, and no generation is opened
+beyond its manifest.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..constants import (
+    CHIMERIC_DIR,
+    HMM_DIR,
+    LATENT_DIR,
+    PREPROCESS_DIR,
+    RAW_DIR,
+    SPATIAL_DIR,
+    VARIANT_DIR,
+)
+
+GENERATIONS_SUBDIR = "generations"
+CURRENT_FILENAME = "current.json"
+GENERATION_MANIFEST = "generation_manifest.json"
+STAGING_SUBDIR = ".staging"
+
+#: Stage directories that may own a ``generations/`` tree, in pipeline order.
+#: Stages without a generation model yet (spatial, hmm, chimeric) are included
+#: deliberately: they are scanned, found to have none, and simply contribute no
+#: records -- so this table does not need editing when they gain one.
+STAGE_GENERATION_DIRS: dict[str, str] = {
+    "raw": RAW_DIR,
+    "preprocess": PREPROCESS_DIR,
+    "variant": VARIANT_DIR,
+    "spatial": SPATIAL_DIR,
+    "hmm": HMM_DIR,
+    "latent": LATENT_DIR,
+    "chimeric": CHIMERIC_DIR,
+}
+
+_TIMESTAMP_KEYS = ("created_at", "completed_at", "published_at", "fitted_at")
+
+STATE_OK = "ok"
+STATE_UNREADABLE = "unreadable"
+STATE_MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class GenerationRecord:
+    """One published generation, or one defect found where a generation should be."""
+
+    scope: str
+    """``"experiment"`` or ``"project"``."""
+
+    kind: str
+    """Stage name (``raw``, ``preprocess``, ``latent``, ...) or ``embedding``."""
+
+    container: str
+    """POSIX path, relative to the scanned root, of the directory owning ``generations/``."""
+
+    generation_id: str
+    path: str
+    """POSIX path to the generation directory, relative to the scanned root."""
+
+    is_current: bool
+    state: str
+    """:data:`STATE_OK`, :data:`STATE_UNREADABLE`, or :data:`STATE_MISSING`."""
+
+    status: str | None
+    config_hash: str | None
+    manifest_schema_version: int | None
+    created_at: str | None
+    """Timestamp from the manifest when it records one; ``None`` otherwise."""
+
+    modified_at: str
+    """Directory mtime, ISO-8601 UTC. Always available, unlike ``created_at``."""
+
+    artifact_count: int | None
+    size_bytes: int | None
+    issues: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["issues"] = list(self.issues)
+        return payload
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(payload, issue)``; never raises for a missing or malformed file."""
+    if not path.is_file():
+        return None, f"{path.name} is missing"
+    try:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{path.name} is unreadable: {type(exc).__name__}"
+    if not isinstance(payload, dict):
+        return None, f"{path.name} is not a JSON object"
+    return payload, None
+
+
+def _iso_mtime(path: Path) -> str:
+    try:
+        stamp = path.stat().st_mtime
+    except OSError:
+        return ""
+    return datetime.fromtimestamp(stamp, tz=timezone.utc).isoformat()
+
+
+def _directory_size(path: Path) -> int | None:
+    total = 0
+    try:
+        for entry in path.rglob("*"):
+            if entry.is_file() and not entry.is_symlink():
+                total += entry.stat().st_size
+    except OSError:
+        return None
+    return total
+
+
+def _manifest_timestamp(manifest: dict[str, Any]) -> str | None:
+    for key in _TIMESTAMP_KEYS:
+        value = manifest.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _artifact_count(manifest: dict[str, Any]) -> int | None:
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, (dict, list, tuple)):
+        return len(artifacts)
+    return None
+
+
+def _current_generation_id(container: Path) -> tuple[str | None, str | None]:
+    """Read ``current.json`` leniently. Returns ``(generation_id, issue)``."""
+    pointer_path = container / CURRENT_FILENAME
+    if not pointer_path.is_file():
+        return None, None
+    pointer, issue = _read_json(pointer_path)
+    if pointer is None:
+        return None, issue
+    generation_id = pointer.get("generation_id")
+    if not generation_id:
+        return None, "current.json names no generation_id"
+    return str(generation_id), None
+
+
+def _records_for_container(
+    container: Path,
+    *,
+    root: Path,
+    scope: str,
+    kind: str,
+    include_size: bool,
+) -> list[GenerationRecord]:
+    generations_dir = container / GENERATIONS_SUBDIR
+    if not generations_dir.is_dir():
+        return []
+
+    container_rel = container.relative_to(root).as_posix()
+    current_id, pointer_issue = _current_generation_id(container)
+
+    records: list[GenerationRecord] = []
+    seen: set[str] = set()
+
+    for generation_dir in sorted(generations_dir.iterdir()):
+        if not generation_dir.is_dir() or generation_dir.name == STAGING_SUBDIR:
+            continue
+        seen.add(generation_dir.name)
+        manifest, manifest_issue = _read_json(generation_dir / GENERATION_MANIFEST)
+        issues: list[str] = []
+        if pointer_issue:
+            issues.append(pointer_issue)
+        if manifest_issue:
+            issues.append(manifest_issue)
+
+        if manifest is None:
+            records.append(
+                GenerationRecord(
+                    scope=scope,
+                    kind=kind,
+                    container=container_rel,
+                    generation_id=generation_dir.name,
+                    path=generation_dir.relative_to(root).as_posix(),
+                    is_current=generation_dir.name == current_id,
+                    state=STATE_UNREADABLE,
+                    status=None,
+                    config_hash=None,
+                    manifest_schema_version=None,
+                    created_at=None,
+                    modified_at=_iso_mtime(generation_dir),
+                    artifact_count=None,
+                    size_bytes=_directory_size(generation_dir) if include_size else None,
+                    issues=tuple(issues),
+                )
+            )
+            continue
+
+        declared_id = str(manifest.get("generation_id", "") or "")
+        if declared_id and declared_id != generation_dir.name:
+            issues.append(f"manifest generation_id {declared_id!r} does not match directory name")
+        schema_version = manifest.get("schema_version")
+        records.append(
+            GenerationRecord(
+                scope=scope,
+                kind=kind,
+                container=container_rel,
+                generation_id=declared_id or generation_dir.name,
+                path=generation_dir.relative_to(root).as_posix(),
+                is_current=generation_dir.name == current_id,
+                state=STATE_OK,
+                status=str(manifest.get("status")) if manifest.get("status") else None,
+                config_hash=(
+                    str(manifest.get("config_hash")) if manifest.get("config_hash") else None
+                ),
+                manifest_schema_version=(
+                    int(schema_version) if isinstance(schema_version, int) else None
+                ),
+                created_at=_manifest_timestamp(manifest),
+                modified_at=_iso_mtime(generation_dir),
+                artifact_count=_artifact_count(manifest),
+                size_bytes=_directory_size(generation_dir) if include_size else None,
+                issues=tuple(issues),
+            )
+        )
+
+    if current_id and current_id not in seen:
+        # A dangling pointer is the most dangerous state here: readers resolve
+        # `current` and fail, while the inventory would otherwise look empty.
+        records.append(
+            GenerationRecord(
+                scope=scope,
+                kind=kind,
+                container=container_rel,
+                generation_id=current_id,
+                path="",
+                is_current=True,
+                state=STATE_MISSING,
+                status=None,
+                config_hash=None,
+                manifest_schema_version=None,
+                created_at=None,
+                modified_at="",
+                artifact_count=None,
+                size_bytes=None,
+                issues=("current.json points at a generation directory that does not exist",),
+            )
+        )
+
+    return records
+
+
+def _iter_experiment_containers(run_root: Path) -> Iterator[tuple[str, Path]]:
+    for kind, stage_dir in STAGE_GENERATION_DIRS.items():
+        container = run_root / stage_dir
+        if container.is_dir():
+            yield kind, container
+
+
+def list_experiment_generations(
+    run_root: str | Path,
+    *,
+    include_size: bool = False,
+) -> list[GenerationRecord]:
+    """Enumerate every generation published under one experiment output root.
+
+    Args:
+        run_root: An experiment's output directory (the one holding
+            ``raw_outputs/``, ``preprocess_adata_outputs/``, ...).
+        include_size: Walk each generation to total its bytes. Off by default
+            because a large store makes it markedly slower, and the common use
+            of this function is "what exists", not "how big".
+
+    Returns:
+        Records in pipeline-stage order. Stages with no generation model, and
+        experiments predating the generation model entirely, contribute nothing
+        rather than raising.
+    """
+    run_root = Path(run_root)
+    records: list[GenerationRecord] = []
+    for kind, container in _iter_experiment_containers(run_root):
+        records.extend(
+            _records_for_container(
+                container,
+                root=run_root,
+                scope="experiment",
+                kind=kind,
+                include_size=include_size,
+            )
+        )
+    return records
+
+
+def list_project_generations(
+    project_dir: str | Path,
+    *,
+    include_size: bool = False,
+) -> list[GenerationRecord]:
+    """Enumerate project-owned generations (currently: embeddings).
+
+    Experiment generations are not included; resolve registered experiments and
+    call :func:`list_experiment_generations` per experiment for those, so the
+    caller controls how unreachable experiment paths are reported.
+    """
+    project_dir = Path(project_dir)
+    from ..project.set_store import sets_root
+
+    records: list[GenerationRecord] = []
+    root = sets_root(project_dir)
+    if not root.is_dir():
+        return records
+    for label_dir in sorted(root.iterdir()):
+        embeddings_dir = label_dir / "embeddings"
+        if not embeddings_dir.is_dir():
+            continue
+        for definition_dir in sorted(embeddings_dir.iterdir()):
+            if not definition_dir.is_dir():
+                continue
+            records.extend(
+                _records_for_container(
+                    definition_dir,
+                    root=project_dir,
+                    scope="project",
+                    kind="embedding",
+                    include_size=include_size,
+                )
+            )
+    return records

--- a/tests/unit/test_generation_listing.py
+++ b/tests/unit/test_generation_listing.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from smftools.constants import LATENT_DIR, PREPROCESS_DIR, RAW_DIR, SPATIAL_DIR
+from smftools.informatics.generation_listing import (
+    CURRENT_FILENAME,
+    GENERATION_MANIFEST,
+    GENERATIONS_SUBDIR,
+    STATE_MISSING,
+    STATE_OK,
+    STATE_UNREADABLE,
+    list_experiment_generations,
+    list_project_generations,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _publish(
+    container: Path,
+    generation_id: str,
+    *,
+    current: bool = False,
+    manifest: dict | None = None,
+    manifest_text: str | None = None,
+) -> Path:
+    """Write a minimal generation tree matching the shared on-disk vocabulary."""
+    generation_dir = container / GENERATIONS_SUBDIR / generation_id
+    generation_dir.mkdir(parents=True, exist_ok=True)
+    payload = (
+        manifest
+        if manifest is not None
+        else {
+            "schema_version": 2,
+            "status": "complete",
+            "generation_id": generation_id,
+            "config_hash": "abc123",
+            "artifacts": {"spine": "spine.h5ad", "obs": "obs.parquet"},
+        }
+    )
+    target = generation_dir / GENERATION_MANIFEST
+    if manifest_text is not None:
+        target.write_text(manifest_text, encoding="utf-8")
+    else:
+        target.write_text(json.dumps(payload), encoding="utf-8")
+    if current:
+        (container / CURRENT_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "generation_id": generation_id,
+                    "generation_path": f"{GENERATIONS_SUBDIR}/{generation_id}",
+                }
+            ),
+            encoding="utf-8",
+        )
+    return generation_dir
+
+
+def test_lists_generations_across_stages_and_marks_current(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-old")
+    _publish(run_root / RAW_DIR, "raw-new", current=True)
+    _publish(run_root / PREPROCESS_DIR, "pp-1", current=True)
+    _publish(run_root / LATENT_DIR, "lat-1", current=True)
+
+    records = list_experiment_generations(run_root)
+
+    assert [(r.kind, r.generation_id) for r in records] == [
+        ("raw", "raw-new"),
+        ("raw", "raw-old"),
+        ("preprocess", "pp-1"),
+        ("latent", "lat-1"),
+    ]
+    assert all(record.state == STATE_OK for record in records)
+    current = {r.generation_id for r in records if r.is_current}
+    assert current == {"raw-new", "pp-1", "lat-1"}
+    raw_new = next(r for r in records if r.generation_id == "raw-new")
+    assert raw_new.config_hash == "abc123"
+    assert raw_new.artifact_count == 2
+    assert raw_new.manifest_schema_version == 2
+    assert raw_new.container == RAW_DIR
+    assert raw_new.path == f"{RAW_DIR}/{GENERATIONS_SUBDIR}/raw-new"
+    assert raw_new.size_bytes is None
+
+
+def test_stage_without_generations_contributes_nothing(tmp_path: Path) -> None:
+    """A legacy in-place stage is absence of data, not an error."""
+    run_root = tmp_path / "outputs"
+    (run_root / SPATIAL_DIR).mkdir(parents=True)
+    (run_root / SPATIAL_DIR / "spine.h5ad").write_bytes(b"")
+    _publish(run_root / RAW_DIR, "raw-1", current=True)
+
+    records = list_experiment_generations(run_root)
+
+    assert [r.kind for r in records] == ["raw"]
+
+
+def test_experiment_predating_generations_lists_empty(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    (run_root / RAW_DIR).mkdir(parents=True)
+    (run_root / PREPROCESS_DIR).mkdir(parents=True)
+
+    assert list_experiment_generations(run_root) == []
+
+
+def test_unreadable_manifest_is_reported_not_raised(tmp_path: Path) -> None:
+    """The truncated-manifest case: listing is the tool you use when it is broken."""
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-good", current=True)
+    _publish(run_root / RAW_DIR, "raw-torn", manifest_text='{"schema_version": 2, "artifa')
+
+    records = list_experiment_generations(run_root)
+    torn = next(r for r in records if r.generation_id == "raw-torn")
+
+    assert torn.state == STATE_UNREADABLE
+    assert torn.config_hash is None
+    assert torn.issues and "unreadable" in torn.issues[0]
+    # The healthy sibling is still reported.
+    assert next(r for r in records if r.generation_id == "raw-good").state == STATE_OK
+
+
+def test_missing_manifest_is_reported(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    (run_root / RAW_DIR / GENERATIONS_SUBDIR / "raw-empty").mkdir(parents=True)
+
+    records = list_experiment_generations(run_root)
+
+    assert len(records) == 1
+    assert records[0].state == STATE_UNREADABLE
+    assert "missing" in records[0].issues[0]
+
+
+def test_dangling_current_pointer_is_surfaced(tmp_path: Path) -> None:
+    """Readers fail hard on this; an inventory that hid it would be worse than useless."""
+    run_root = tmp_path / "outputs"
+    container = run_root / RAW_DIR
+    _publish(container, "raw-1", current=True)
+    (container / GENERATIONS_SUBDIR / "raw-1" / GENERATION_MANIFEST).unlink()
+    (container / GENERATIONS_SUBDIR / "raw-1").rmdir()
+
+    records = list_experiment_generations(run_root)
+
+    assert len(records) == 1
+    assert records[0].state == STATE_MISSING
+    assert records[0].is_current is True
+    assert records[0].generation_id == "raw-1"
+    assert "does not exist" in records[0].issues[0]
+
+
+def test_generation_id_mismatch_is_flagged_but_listed(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(
+        run_root / RAW_DIR,
+        "dir-name",
+        manifest={"schema_version": 2, "status": "complete", "generation_id": "other-name"},
+    )
+
+    records = list_experiment_generations(run_root)
+
+    assert records[0].state == STATE_OK
+    assert any("does not match directory name" in issue for issue in records[0].issues)
+
+
+def test_staging_directory_is_ignored(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-1", current=True)
+    (run_root / RAW_DIR / GENERATIONS_SUBDIR / ".staging").mkdir()
+
+    records = list_experiment_generations(run_root)
+
+    assert [r.generation_id for r in records] == ["raw-1"]
+
+
+def test_include_size_totals_generation_bytes(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    generation = _publish(run_root / RAW_DIR, "raw-1", current=True)
+    (generation / "payload.bin").write_bytes(b"x" * 128)
+
+    records = list_experiment_generations(run_root, include_size=True)
+
+    assert records[0].size_bytes is not None
+    assert records[0].size_bytes >= 128
+
+
+def test_to_dict_is_json_serializable(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-1", current=True)
+
+    payload = list_experiment_generations(run_root)[0].to_dict()
+
+    assert json.loads(json.dumps(payload))["generation_id"] == "raw-1"
+    assert isinstance(payload["issues"], list)
+
+
+def test_project_embedding_generations_are_listed(tmp_path: Path) -> None:
+    from smftools.project.set_store import sets_root
+
+    definition_dir = sets_root(tmp_path) / "my_set" / "embeddings" / "def0123"
+    _publish(definition_dir, "emb-1", current=True)
+
+    records = list_project_generations(tmp_path)
+
+    assert len(records) == 1
+    assert records[0].scope == "project"
+    assert records[0].kind == "embedding"
+    assert records[0].is_current is True
+    assert records[0].container.endswith("embeddings/def0123")
+
+
+def test_project_without_embeddings_lists_empty(tmp_path: Path) -> None:
+    assert list_project_generations(tmp_path) == []

--- a/tests/unit/test_generations_cli.py
+++ b/tests/unit/test_generations_cli.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from smftools.cli.generations import render_json, render_table
+from smftools.cli_entry import cli
+from smftools.constants import PREPROCESS_DIR, RAW_DIR
+from smftools.informatics.generation_listing import (
+    CURRENT_FILENAME,
+    GENERATION_MANIFEST,
+    GENERATIONS_SUBDIR,
+    list_experiment_generations,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _publish(container: Path, generation_id: str, *, current: bool = False) -> None:
+    generation_dir = container / GENERATIONS_SUBDIR / generation_id
+    generation_dir.mkdir(parents=True, exist_ok=True)
+    (generation_dir / GENERATION_MANIFEST).write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "status": "complete",
+                "generation_id": generation_id,
+                "config_hash": "hash0001",
+                "artifacts": {"spine": "spine.h5ad"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    if current:
+        (container / CURRENT_FILENAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "generation_id": generation_id,
+                    "generation_path": f"{GENERATIONS_SUBDIR}/{generation_id}",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def test_render_table_marks_current_and_summarizes(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "gen-current", current=True)
+    _publish(run_root / RAW_DIR, "gen-superseded")
+
+    table = render_table(list_experiment_generations(run_root))
+
+    assert "gen-current" in table
+    assert "gen-superseded" in table
+    current_line = next(line for line in table.splitlines() if "gen-current" in line)
+    superseded_line = next(line for line in table.splitlines() if "gen-superseded" in line)
+    assert current_line.startswith("*")
+    assert not superseded_line.startswith("*")
+    assert "2 generation(s); 1 current, 2 readable, 0 unreadable or missing." in table
+
+
+def test_render_table_does_not_truncate_generation_ids(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    long_id = "pod5-sup52-provenance-rebuild-2026"
+    _publish(run_root / RAW_DIR, long_id, current=True)
+
+    assert long_id in render_table(list_experiment_generations(run_root))
+
+
+def test_render_table_empty_is_explicit(tmp_path: Path) -> None:
+    assert render_table([]) == "No published generations found."
+
+
+def test_render_json_is_stable_and_versioned(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / PREPROCESS_DIR, "pp-1", current=True)
+
+    payload = json.loads(render_json(list_experiment_generations(run_root)))
+
+    assert payload["schema_version"] == 1
+    assert len(payload["generations"]) == 1
+    entry = payload["generations"][0]
+    assert entry["kind"] == "preprocess"
+    assert entry["generation_id"] == "pp-1"
+    assert entry["is_current"] is True
+
+
+def test_cli_experiment_generations_reports_empty_store(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    (run_root / RAW_DIR).mkdir(parents=True)
+
+    result = CliRunner().invoke(cli, ["experiment", "generations", str(run_root)])
+
+    assert result.exit_code == 0
+    assert "No published generations found." in result.output
+
+
+def test_cli_experiment_generations_json(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-1", current=True)
+
+    result = CliRunner().invoke(cli, ["experiment", "generations", str(run_root), "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["generations"][0]["generation_id"] == "raw-1"
+
+
+def test_cli_size_flag_populates_bytes(tmp_path: Path) -> None:
+    run_root = tmp_path / "outputs"
+    _publish(run_root / RAW_DIR, "raw-1", current=True)
+
+    without = CliRunner().invoke(cli, ["experiment", "generations", str(run_root), "--json"])
+    with_size = CliRunner().invoke(
+        cli, ["experiment", "generations", str(run_root), "--json", "--size"]
+    )
+
+    assert json.loads(without.output)["generations"][0]["size_bytes"] is None
+    assert json.loads(with_size.output)["generations"][0]["size_bytes"] > 0
+
+
+def test_cli_project_generations_project_only_skips_experiments(tmp_path: Path) -> None:
+    from smftools.project.set_store import sets_root
+
+    _publish(sets_root(tmp_path) / "my_set" / "embeddings" / "def0", "emb-1", current=True)
+
+    result = CliRunner().invoke(
+        cli, ["project", "generations", str(tmp_path), "--project-only", "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert [entry["kind"] for entry in payload["generations"]] == ["embedding"]


### PR DESCRIPTION
Four subsystems publish immutable generations -- raw, preprocess, latent, and project embeddings -- but nothing enumerates them, so retention was a policy nobody could apply and a dangling `current.json` was invisible until a reader failed on it.

Add `smftools experiment generations` and `smftools project generations`, both read-only, with `--json` for the stable schema and `--size` to total bytes on disk (off by default; walking a large store is slow and the common question is what exists, not how big).

The reader deliberately does not call the per-kind `resolve_current_*` validators. Those raise on the first defect, which is right for a consumer about to read a generation and wrong for an inventory: listing is what you reach for when something is already broken. Every defect -- torn manifest, missing manifest, id/directory mismatch, dangling current pointer -- is reported as a record field instead. Stores predating the generation model, and stages that have none yet, list empty rather than raising.

The four layouts already converged on the same on-disk vocabulary (`generations/<id>/generation_manifest.json` beside an atomic `current.json`), differing only in manifest payload, so discovery needs no per-kind branching. That convergence is also evidence for the shared `informatics/generation.py` helper proposed as EGL-01.