### PR TITLE
fix: drop sequenceless alignment records instead of aborting the run

### DIFF
--- a/src/smftools/informatics/alignment_validation.py
+++ b/src/smftools/informatics/alignment_validation.py
@@ -12,12 +12,26 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from ..logging_utils import get_logger
 from ..readwrite import atomic_write_json
 from .raw_intermediate_manifest import alignment_reference_bundle, artifact_checksum
+
+logger = get_logger(__name__)
 
 
 class AlignmentValidationError(ValueError):
     """Raised when an existing alignment violates the ingestion contract."""
+
+
+SEQUENCELESS_PRIMARY_FRACTION_LIMIT = 0.01
+"""Largest tolerated share of primary records emitted without SEQ/base qualities.
+
+Aligners occasionally emit a handful of such records -- observed at 43 of 289,209
+(0.015%) from dorado's minimap2, on reads carrying extreme soft-clipping. A record
+with no sequence carries no data, so it is dropped and counted rather than
+ingested. Above this fraction the file is not credibly usable, and the original
+hard failure is the right answer.
+"""
 
 
 @dataclass(frozen=True)
@@ -41,6 +55,9 @@ class AlignmentValidationSummary:
     reference_records: tuple[tuple[str, int], ...]
     program_records: tuple[dict[str, str], ...]
     external_aligner: str
+    sequenceless_primary_records: int = 0
+    """Primary records dropped because the aligner emitted them without SEQ or
+    base qualities. See :data:`SEQUENCELESS_PRIMARY_FRACTION_LIMIT`."""
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible validation payload."""
@@ -274,7 +291,7 @@ def validate_existing_alignment(
                     source_index_valid = False
 
             total = primary = mapped = secondary = supplementary = paired = mm_ml = 0
-            proper_pair = singleton = discordant = 0
+            proper_pair = singleton = discordant = sequenceless = 0
             coordinate_sorted = True
             last_reference = -1
             last_start = -1
@@ -288,14 +305,13 @@ def validate_existing_alignment(
                     supplementary += 1
                     continue
                 primary += 1
-                if read.query_sequence is None:
-                    raise AlignmentValidationError(
-                        f"Primary alignment {read.query_name!r} has no query sequence."
-                    )
-                if read.query_qualities is None:
-                    raise AlignmentValidationError(
-                        f"Primary alignment {read.query_name!r} has no base qualities."
-                    )
+                if read.query_sequence is None or read.query_qualities is None:
+                    # No sequence means no data to ingest, so drop the record and
+                    # count it. The fraction is checked once at the end: aligner
+                    # noise must not abort a run, a wholesale-unusable file still
+                    # must.
+                    sequenceless += 1
+                    continue
                 if read.is_paired:
                     paired += 1
                     if read.is_read1 == read.is_read2:
@@ -375,9 +391,27 @@ def validate_existing_alignment(
 
     if total == 0 or primary == 0:
         raise AlignmentValidationError("Existing alignment contains no primary records.")
+    if sequenceless:
+        fraction = sequenceless / primary
+        if fraction > SEQUENCELESS_PRIMARY_FRACTION_LIMIT:
+            raise AlignmentValidationError(
+                f"Existing alignment has {sequenceless} of {primary} primary records "
+                f"({fraction:.2%}) without SEQ or base qualities, above the "
+                f"{SEQUENCELESS_PRIMARY_FRACTION_LIMIT:.2%} limit."
+            )
+        logger.warning(
+            "Dropping %d of %d primary alignment records (%.3f%%) that carry no SEQ or base "
+            "qualities; recorded as sequenceless_primary_records.",
+            sequenceless,
+            primary,
+            fraction * 100,
+        )
     if mapped == 0:
         raise AlignmentValidationError("Existing alignment contains no mapped primary records.")
-    if str(modality).strip().lower() == "direct" and mm_ml != primary:
+    # Compare against the records actually ingested: dropped sequenceless records
+    # never reached the MM/ML check, so counting them here would fail a direct
+    # experiment for the wrong reason.
+    if str(modality).strip().lower() == "direct" and mm_ml != primary - sequenceless:
         raise AlignmentValidationError(
             "Direct-modification existing alignment requires valid MM/ML tags on every primary read."
         )
@@ -403,6 +437,7 @@ def validate_existing_alignment(
         reference_records=observed_references,
         program_records=programs,
         external_aligner=aligner,
+        sequenceless_primary_records=sequenceless,
     )
 
 

--- a/tests/unit/informatics/test_alignment_validation.py
+++ b/tests/unit/informatics/test_alignment_validation.py
@@ -295,8 +295,10 @@ def test_missing_external_aligner_provenance_is_recorded_as_unknown(tmp_path):
 @pytest.mark.parametrize(
     ("field", "kwargs", "message"),
     [
-        ("sequence", {"sequence": False, "qualities": False}, "no query sequence"),
-        ("qualities", {"qualities": False}, "no base qualities"),
+        # A wholly sequenceless file is 100% sequenceless -- far above the tolerated
+        # fraction -- so it is still rejected, now by the fraction check.
+        ("sequence", {"sequence": False, "qualities": False}, "without SEQ or base qualities"),
+        ("qualities", {"qualities": False}, "without SEQ or base qualities"),
         ("CIGAR", {"cigar": False}, "no CIGAR"),
     ],
 )
@@ -306,6 +308,61 @@ def test_required_alignment_fields_fail(tmp_path, field, kwargs, message):
 
     with pytest.raises(AlignmentValidationError, match=message):
         validate_existing_alignment(source, fasta, modality="conversion")
+
+
+def _bam_with_sequenceless(path, *, total, sequenceless, reference_length=12):
+    """Write a BAM whose first ``sequenceless`` primary records carry no SEQ/QUAL."""
+    header = {
+        "HD": {"VN": "1.6", "SO": "coordinate"},
+        "SQ": [{"SN": "ref", "LN": reference_length}],
+        "PG": [{"ID": "minimap2", "PN": "minimap2", "VN": "2.28"}],
+    }
+    with pysam.AlignmentFile(str(path), "wb", header=header) as bam:
+        for index in range(total):
+            read = pysam.AlignedSegment()
+            read.query_name = f"read-{index}"
+            read.reference_id = 0
+            read.reference_start = 1
+            read.mapping_quality = 60
+            read.flag = 0
+            if index >= sequenceless:
+                read.query_sequence = "ACGT"
+                read.query_qualities = array("B", [30, 30, 30, 30])
+                read.cigarstring = "4M"
+            bam.write(read)
+    return path
+
+
+def test_rare_sequenceless_records_are_dropped_and_counted(tmp_path):
+    """Aligner noise must not abort a run: 1 of 200 is below the tolerated fraction."""
+    fasta = _fasta(tmp_path / "reference.fa")
+    source = _bam_with_sequenceless(tmp_path / "noisy.bam", total=200, sequenceless=1)
+
+    summary = validate_existing_alignment(source, fasta, modality="conversion")
+
+    assert summary.sequenceless_primary_records == 1
+    assert summary.primary_records == 200
+    # The dropped record never reaches the ingested/mapped counts.
+    assert summary.mapped_primary_records == 199
+    assert summary.to_dict()["sequenceless_primary_records"] == 1
+
+
+def test_many_sequenceless_records_still_fail(tmp_path):
+    """A wholesale-unusable file is what the original hard failure protected against."""
+    fasta = _fasta(tmp_path / "reference.fa")
+    source = _bam_with_sequenceless(tmp_path / "broken.bam", total=100, sequenceless=50)
+
+    with pytest.raises(AlignmentValidationError, match="above the"):
+        validate_existing_alignment(source, fasta, modality="conversion")
+
+
+def test_clean_alignment_reports_zero_sequenceless(tmp_path):
+    fasta = _fasta(tmp_path / "reference.fa")
+    source = _bam_with_sequenceless(tmp_path / "clean.bam", total=10, sequenceless=0)
+
+    summary = validate_existing_alignment(source, fasta, modality="conversion")
+
+    assert summary.sequenceless_primary_records == 0
 
 
 def test_invalid_paired_flags_fail_early(tmp_path):


### PR DESCRIPTION
`validate_existing_alignment` raised on the first primary record lacking SEQ or base qualities. Dorado's minimap2 emits a small number of these on reads with extreme soft-clipping -- observed at 43 of 289,209 (0.016%) on a real conversion run -- so a four-minute ingestion died over records that carry no data in the first place, and would have died identically on every subsequent run.

A record with no sequence has nothing to ingest, so drop and count it, and apply the fraction check once at the end: above
SEQUENCELESS_PRIMARY_FRACTION_LIMIT (1%) the file is not credibly usable and the original hard failure is still the right answer. A wholly sequenceless BAM is 100% sequenceless, so the existing rejection tests still reject -- they now match on the fraction message rather than the per-record one.

The count is surfaced as `sequenceless_primary_records` on the validation summary so the drop is visible in provenance rather than silent.

Also compare the direct-modality MM/ML requirement against the records actually ingested (`primary - sequenceless`), since dropped records never reach that check and would otherwise fail a direct experiment for the wrong reason.