### PR TITLE
feat: add the shared immutable-generation publication helper

### DIFF
--- a/src/smftools/informatics/generation.py
+++ b/src/smftools/informatics/generation.py
@@ -1,0 +1,222 @@
+"""Shared publication vocabulary for immutable generations.
+
+Four subsystems already publish immutable generations, each with its own
+publish/resolve pair: raw (:mod:`.raw_generation`), preprocess
+(:mod:`smftools.preprocessing.preprocess_generation`), latent
+(:mod:`smftools.tools.partitioned_latent`), and project embeddings
+(:mod:`smftools.project.embedding_store`). They converged independently on one
+on-disk shape::
+
+    <output_dir>/
+      current.json                       # atomic pointer to the readable generation
+      generations/<generation_id>/
+        generation_manifest.json
+        ...                              # kind-specific artifacts
+      .staging/<generation_id>/          # build area, never read by consumers
+
+This module is that shape, factored out once, for kinds that do not have it yet.
+It deliberately does **not** rewrite the four existing implementations: they are
+working and tested, their on-disk layouts are load-bearing for published data,
+and consolidating them changes no layout, so it can follow separately.
+
+The transaction is the point. A generation becomes visible only when it is
+complete: artifacts are built under ``.staging/``, validated, moved into place
+with a single :func:`os.replace`, and only then does ``current.json`` advance. A
+failure at any step leaves the previously current generation untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterator
+from uuid import uuid4
+
+from ..logging_utils import get_logger
+from ..readwrite import atomic_write_json
+
+logger = get_logger(__name__)
+
+GENERATIONS_SUBDIR = "generations"
+STAGING_SUBDIR = ".staging"
+CURRENT_FILENAME = "current.json"
+GENERATION_MANIFEST = "generation_manifest.json"
+CURRENT_SCHEMA_VERSION = 1
+
+
+class GenerationError(RuntimeError):
+    """Raised when a generation cannot be published or selected safely."""
+
+
+@dataclass
+class StagedGeneration:
+    """One in-flight generation. Build into :attr:`staging_dir`, then record a manifest."""
+
+    generation_id: str
+    staging_dir: Path
+    final_dir: Path
+    output_dir: Path
+    run_root: Path
+    _manifest: dict[str, Any] | None = field(default=None, init=False, repr=False)
+
+    def record_manifest(self, payload: dict[str, Any]) -> None:
+        """Declare this generation's manifest. Required before a clean exit.
+
+        ``generation_id`` is stamped here rather than trusted from the caller, so
+        the manifest and the directory name cannot disagree.
+        """
+        if not isinstance(payload, dict):
+            raise GenerationError("generation manifest payload must be a dict")
+        self._manifest = {**payload, "generation_id": self.generation_id}
+
+    def artifact(self, *parts: str) -> Path:
+        """Return a path inside the staging directory, creating parent directories."""
+        target = self.staging_dir.joinpath(*parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
+
+
+def _current_path(output_dir: Path) -> Path:
+    return output_dir / CURRENT_FILENAME
+
+
+@contextmanager
+def staged_generation(
+    output_dir: str | Path,
+    *,
+    run_root: str | Path | None = None,
+    validate: Callable[[Path, Path, Path], None] | None = None,
+    generation_id: str | None = None,
+) -> Iterator[StagedGeneration]:
+    """Build and atomically publish one immutable generation.
+
+    Args:
+        output_dir: The kind's directory (e.g. ``<run>/hmm_adata_outputs``).
+        run_root: Anchor for relative artifact pointers. Defaults to
+            ``output_dir.parent``.
+        validate: Optional ``(staging_dir, final_dir, run_root)`` callable run
+            after the manifest is written and before the move. Raise from it to
+            abort; the staging tree is removed and ``current.json`` never moves.
+        generation_id: Override the generated id. For tests and for republishing
+            a known id; normally leave unset.
+
+    Yields:
+        A :class:`StagedGeneration`. The caller must call
+        :meth:`StagedGeneration.record_manifest` before the block exits cleanly.
+
+    Raises:
+        GenerationError: If no manifest was recorded, or the generation id is
+            already published.
+    """
+    output_dir = Path(output_dir)
+    run_root = Path(run_root) if run_root is not None else output_dir.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generation_id = generation_id or uuid4().hex
+    staging_dir = output_dir / STAGING_SUBDIR / generation_id
+    final_dir = output_dir / GENERATIONS_SUBDIR / generation_id
+    if final_dir.exists():
+        raise GenerationError(f"generation {generation_id!r} is already published")
+
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    staging_dir.mkdir(parents=True)
+    final_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    staged = StagedGeneration(
+        generation_id=generation_id,
+        staging_dir=staging_dir,
+        final_dir=final_dir,
+        output_dir=output_dir,
+        run_root=run_root,
+    )
+
+    moved = False
+    try:
+        yield staged
+        if staged._manifest is None:
+            raise GenerationError(
+                f"generation {generation_id!r} recorded no manifest; "
+                "call record_manifest() before leaving the staged_generation block"
+            )
+        atomic_write_json(staging_dir / GENERATION_MANIFEST, staged._manifest)
+        if validate is not None:
+            validate(staging_dir, final_dir, run_root)
+        os.replace(staging_dir, final_dir)
+        moved = True
+        atomic_write_json(
+            _current_path(output_dir),
+            {
+                "schema_version": CURRENT_SCHEMA_VERSION,
+                "generation_id": generation_id,
+                "generation_path": final_dir.relative_to(output_dir).as_posix(),
+            },
+        )
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        if moved:
+            # The move succeeded but advancing `current` did not. Remove the
+            # orphan so it cannot be mistaken for a published generation; the
+            # previously current one is still selected and untouched.
+            shutil.rmtree(final_dir, ignore_errors=True)
+        raise
+    logger.info("Published %s generation %s", output_dir.name, generation_id)
+
+
+def resolve_current_generation(
+    output_dir: str | Path,
+) -> tuple[Path, dict[str, Any]] | None:
+    """Return ``(generation_dir, manifest)`` for the selected generation.
+
+    Returns ``None`` when nothing is published yet, which is how a legacy
+    in-place output directory presents. Raises rather than guessing when a
+    pointer exists but does not resolve safely.
+    """
+    output_dir = Path(output_dir)
+    pointer_path = _current_path(output_dir)
+    if not pointer_path.is_file():
+        return None
+    try:
+        pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GenerationError(f"{output_dir.name} current pointer is unreadable") from exc
+    if int(pointer.get("schema_version", -1)) != CURRENT_SCHEMA_VERSION:
+        raise GenerationError(f"{output_dir.name} current-pointer schema is incompatible")
+
+    # Check the raw string before Path(): Path("") is Path("."), which would
+    # resolve to output_dir itself and pass every containment test below.
+    raw_path = str(pointer.get("generation_path", "")).strip()
+    relative = Path(raw_path)
+    generation = (output_dir / relative).resolve()
+    if (
+        not raw_path
+        or relative.is_absolute()
+        or ".." in relative.parts
+        or generation == output_dir.resolve()
+        or not generation.is_relative_to(output_dir.resolve())
+    ):
+        raise GenerationError(f"{output_dir.name} current pointer is not portable")
+
+    manifest_path = generation / GENERATION_MANIFEST
+    if not manifest_path.is_file():
+        raise GenerationError(f"{output_dir.name} current generation has no manifest")
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GenerationError(f"{output_dir.name} current manifest is unreadable") from exc
+
+    expected = str(pointer.get("generation_id", ""))
+    if expected and str(manifest.get("generation_id", "")) != expected:
+        raise GenerationError(
+            f"{output_dir.name} current pointer names {expected!r} but the manifest does not"
+        )
+    return generation, manifest
+
+
+def has_published_generations(output_dir: str | Path) -> bool:
+    """True when at least one generation directory exists under ``output_dir``."""
+    root = Path(output_dir) / GENERATIONS_SUBDIR
+    return root.is_dir() and any(child.is_dir() for child in root.iterdir())

--- a/tests/unit/informatics/test_generation.py
+++ b/tests/unit/informatics/test_generation.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from smftools.informatics.generation import (
+    CURRENT_FILENAME,
+    GENERATION_MANIFEST,
+    GENERATIONS_SUBDIR,
+    STAGING_SUBDIR,
+    GenerationError,
+    has_published_generations,
+    resolve_current_generation,
+    staged_generation,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _publish(output_dir: Path, *, payload=None, generation_id=None, body=b"x") -> str:
+    with staged_generation(output_dir, generation_id=generation_id) as staged:
+        staged.artifact("store", "part-0.parquet").write_bytes(body)
+        staged.record_manifest(payload or {"schema_version": 1, "status": "complete"})
+    return staged.generation_id
+
+
+def test_publishes_generation_and_advances_current(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+
+    generation_id = _publish(out)
+
+    generation_dir = out / GENERATIONS_SUBDIR / generation_id
+    assert (generation_dir / GENERATION_MANIFEST).is_file()
+    assert (generation_dir / "store" / "part-0.parquet").is_file()
+
+    pointer = json.loads((out / CURRENT_FILENAME).read_text())
+    assert pointer["generation_id"] == generation_id
+    assert pointer["generation_path"] == f"{GENERATIONS_SUBDIR}/{generation_id}"
+    assert not Path(pointer["generation_path"]).is_absolute()
+
+    resolved = resolve_current_generation(out)
+    assert resolved is not None
+    assert resolved[0] == generation_dir
+    assert resolved[1]["generation_id"] == generation_id
+
+
+def test_manifest_generation_id_is_stamped_not_trusted(tmp_path: Path) -> None:
+    """The manifest and directory name cannot disagree, even if a caller tries."""
+    out = tmp_path / "hmm_adata_outputs"
+
+    generation_id = _publish(out, payload={"schema_version": 1, "generation_id": "lies"})
+
+    manifest = json.loads(
+        (out / GENERATIONS_SUBDIR / generation_id / GENERATION_MANIFEST).read_text()
+    )
+    assert manifest["generation_id"] == generation_id
+
+
+def test_second_generation_supersedes_without_destroying_the_first(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    first = _publish(out, body=b"first")
+    second = _publish(out, body=b"second")
+
+    assert first != second
+    # Both remain addressable; only the pointer moved.
+    assert (out / GENERATIONS_SUBDIR / first / "store" / "part-0.parquet").read_bytes() == b"first"
+    assert (
+        out / GENERATIONS_SUBDIR / second / "store" / "part-0.parquet"
+    ).read_bytes() == b"second"
+    assert resolve_current_generation(out)[1]["generation_id"] == second
+
+
+def test_failure_inside_the_block_publishes_nothing(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    published = _publish(out, body=b"good")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with staged_generation(out) as staged:
+            staged.artifact("store", "part-0.parquet").write_bytes(b"bad")
+            staged.record_manifest({"schema_version": 1})
+            raise RuntimeError("boom")
+
+    # The previously current generation is untouched and still selected.
+    assert resolve_current_generation(out)[1]["generation_id"] == published
+    assert [d.name for d in (out / GENERATIONS_SUBDIR).iterdir()] == [published]
+    assert not any((out / STAGING_SUBDIR).iterdir())
+
+
+def test_validator_failure_aborts_before_publication(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+
+    def _reject(staging_dir, final_dir, run_root):
+        raise GenerationError("incomplete")
+
+    with pytest.raises(GenerationError, match="incomplete"):
+        with staged_generation(out, validate=_reject) as staged:
+            staged.artifact("store", "part-0.parquet").write_bytes(b"x")
+            staged.record_manifest({"schema_version": 1})
+
+    assert not (out / CURRENT_FILENAME).exists()
+    assert not has_published_generations(out)
+
+
+def test_missing_manifest_is_an_error_and_publishes_nothing(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+
+    with pytest.raises(GenerationError, match="recorded no manifest"):
+        with staged_generation(out) as staged:
+            staged.artifact("store", "part-0.parquet").write_bytes(b"x")
+
+    assert not (out / CURRENT_FILENAME).exists()
+    assert not has_published_generations(out)
+
+
+def test_republishing_an_existing_id_is_refused(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    _publish(out, generation_id="fixed-id")
+
+    with pytest.raises(GenerationError, match="already published"):
+        _publish(out, generation_id="fixed-id")
+
+
+def test_legacy_in_place_directory_resolves_to_none(tmp_path: Path) -> None:
+    """A stage that predates generations is absence of a pointer, not an error."""
+    out = tmp_path / "hmm_adata_outputs"
+    out.mkdir()
+    (out / "spine.h5ad").write_bytes(b"")
+
+    assert resolve_current_generation(out) is None
+    assert not has_published_generations(out)
+
+
+@pytest.mark.parametrize(
+    ("pointer", "message"),
+    [
+        ({"schema_version": 99, "generation_path": "generations/x"}, "schema is incompatible"),
+        ({"schema_version": 1, "generation_path": "/etc"}, "not portable"),
+        ({"schema_version": 1, "generation_path": "../escape"}, "not portable"),
+        ({"schema_version": 1, "generation_path": ""}, "not portable"),
+    ],
+)
+def test_unsafe_current_pointers_are_rejected(tmp_path: Path, pointer, message) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    out.mkdir()
+    (out / CURRENT_FILENAME).write_text(json.dumps(pointer), encoding="utf-8")
+
+    with pytest.raises(GenerationError, match=message):
+        resolve_current_generation(out)
+
+
+def test_pointer_naming_a_different_generation_than_the_manifest_is_rejected(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    generation_id = _publish(out)
+    pointer_path = out / CURRENT_FILENAME
+    pointer = json.loads(pointer_path.read_text())
+    pointer["generation_id"] = "someone-else"
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8")
+
+    with pytest.raises(GenerationError, match="does not"):
+        resolve_current_generation(out)
+
+    assert generation_id  # the generation itself is still on disk
+
+
+def test_unreadable_pointer_is_rejected(tmp_path: Path) -> None:
+    out = tmp_path / "hmm_adata_outputs"
+    out.mkdir()
+    (out / CURRENT_FILENAME).write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(GenerationError, match="unreadable"):
+        resolve_current_generation(out)


### PR DESCRIPTION
Four subsystems already publish immutable generations -- raw, preprocess, latent, and project embeddings -- each with its own publish/resolve pair, and they had independently converged on one on-disk shape: `current.json` beside `generations/<id>/generation_manifest.json`, built via `.staging/`. Kinds that should have generations but do not (hmm, spatial, and basecalls under the SRB reconciliation) had no shared thing to adopt.

Factor that shape out once as `informatics/generation.py`, exposing a `staged_generation` context manager, `resolve_current_generation`, and `has_published_generations`.

The transaction is the point: a generation becomes visible only when it is complete. Artifacts are built under `.staging/`, the manifest is written, an optional validator runs, the tree is moved with a single `os.replace`, and only then does `current.json` advance. Any failure removes the staging tree and leaves the previously current generation selected and untouched -- including the narrow window where the move succeeded but the pointer write did not, where the orphan is removed rather than left to look published.

`generation_id` is stamped into the manifest by the helper rather than trusted from the caller, so a manifest and its directory name cannot disagree.

Deliberately does NOT rewrite the four existing implementations. They are working and tested, their layouts are load-bearing for already-published data, and consolidating them changes no on-disk layout -- so it can follow separately rather than blocking the kinds that need generations now.

Because the vocabulary matches, `smftools experiment generations` lists generations published through this helper with no changes of its own.