### PR TITLE
feat: run the descendant raw stage inside its lineage transaction

### DIFF
--- a/src/smftools/cli/raw_adata.py
+++ b/src/smftools/cli/raw_adata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import time
 from pathlib import Path
+from typing import Any, Mapping
 
 import numpy as np
 import pandas as pd
@@ -1703,8 +1704,14 @@ def build_partitioned_ragged_records_streaming(
 
 
 @stage_logging_lifecycle
-def raw_adata(config_path: str):
-    """Run BAM preparation through section 6 and emit ragged raw artifacts."""
+def raw_adata(config_path: str, *, lineage_provenance: Mapping[str, Any] | None = None):
+    """Run BAM preparation through section 6 and emit ragged raw artifacts.
+
+    ``lineage_provenance`` marks the result as a re-basecalled descendant. Such a
+    run publishes beside the parent's generation without advancing
+    ``current.json``, and never takes the append path: a selected cohort is a
+    parallel lineage, not a later state of the parent's source universe.
+    """
     from ..logging_utils import setup_stage_logging
     from ..perf_log import perf_substep
     from ..readwrite import safe_read_h5ad
@@ -1817,6 +1824,8 @@ def raw_adata(config_path: str):
                 if append_plan is not None and append_plan.eligible
                 else None
             ),
+            lineage_provenance=lineage_provenance,
+            select_current=lineage_provenance is None,
         )
 
     def lifecycle_outputs(generation):
@@ -1838,6 +1847,11 @@ def raw_adata(config_path: str):
     except RawGenerationError as exc:
         current_generation = None
         logger.warning("Raw current generation is invalid; rebuilding: %s", exc)
+    if lineage_provenance is not None:
+        # A descendant is published beside whatever is current, never instead of
+        # it and never as an addition to it, so neither the completeness skip nor
+        # the append path applies.
+        current_generation = None
     if current_generation is not None and not cfg.force_redo_load_adata:
         generation_id = str(current_generation[1]["generation_id"])
         current_spine = current_generation[0] / "spine.h5ad"

--- a/src/smftools/pipeline/__init__.py
+++ b/src/smftools/pipeline/__init__.py
@@ -73,6 +73,12 @@ from .rebasecall_request import (
     parse_selection_predicate,
     rebasecall_request_from_dict,
 )
+from .rebasecall_run import (
+    DESCENDANT_CONFIG_FILENAME,
+    LineageRawStageResult,
+    derive_descendant_config,
+    run_lineage_raw_stage,
+)
 from .rebasecall_selection import (
     REBASECALL_SELECTION_SCHEMA_VERSION,
     FrozenRebasecallSelection,
@@ -125,11 +131,13 @@ __all__ = [
     "ChannelSpec",
     "CompatibilityFingerprint",
     "DependencyResultIdentity",
+    "DESCENDANT_CONFIG_FILENAME",
     "EXPERIMENT_NODE_IDS",
     "EXPERIMENT_STAGES",
     "EXPERIMENT_TARGETS",
     "ExperimentExecutionResult",
     "FrozenRebasecallSelection",
+    "LineageRawStageResult",
     "MaterializedRebasecallSignal",
     "NodeInputs",
     "NodeResult",
@@ -177,6 +185,7 @@ __all__ = [
     "build_rebasecall_plan",
     "build_upgrade_impact",
     "compatibility_fingerprint",
+    "derive_descendant_config",
     "descendant_raw_provenance",
     "execute_experiment_target",
     "execute_rebasecall_basecall",
@@ -206,6 +215,7 @@ __all__ = [
     "read_materialized_rebasecall_signal",
     "read_published_rebasecall_basecall",
     "read_published_rebasecall_lineage",
+    "run_lineage_raw_stage",
     "resolve_experiment_target",
     "staged_lineage",
     "write_lineage_validation",

--- a/src/smftools/pipeline/rebasecall_run.py
+++ b/src/smftools/pipeline/rebasecall_run.py
@@ -1,0 +1,178 @@
+"""Run a descendant raw stage beneath a staged re-basecalling lineage."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .rebasecall_basecall import BASECALL_BAM_FILENAME, PublishedRebasecallBasecall
+from .rebasecall_lineage import (
+    PublishedRebasecallLineage,
+    RebasecallLineageError,
+    build_lineage_identity,
+    descendant_raw_provenance,
+    read_published_rebasecall_lineage,
+    staged_lineage,
+)
+from .rebasecall_plan import RebasecallPlan
+from .rebasecall_selection import FrozenRebasecallSelection
+
+DESCENDANT_CONFIG_FILENAME = "descendant_config.csv"
+
+# Fields the descendant overrides. Everything else is inherited verbatim: a
+# lineage re-runs the *same* experiment against new calls, so silently changing
+# a reference or a threshold here would make the comparison meaningless.
+_OVERRIDDEN_CONFIG_FIELDS = ("input_data_path", "input_manifest_path", "alignment_mode")
+
+
+@dataclass(frozen=True)
+class LineageRawStageResult:
+    """The workflow-contract result of running one lineage's raw stage."""
+
+    lineage: PublishedRebasecallLineage
+    raw_generation_id: str
+    descendant_config_path: Path
+    run_root: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the engine-facing result payload."""
+        return {
+            "lineage_id": self.lineage.lineage_id,
+            "basecall_id": self.lineage.basecall_id,
+            "stage_generations": self.lineage.stage_generations,
+            "raw_generation_id": self.raw_generation_id,
+            "run_root": str(self.run_root),
+            "descendant_config_path": str(self.descendant_config_path),
+        }
+
+
+def _read_config_rows(config_path: Path) -> list[list[str]]:
+    try:
+        with config_path.open(newline="", encoding="utf-8-sig") as handle:
+            return [row for row in csv.reader(handle) if row]
+    except OSError as exc:
+        raise RebasecallLineageError(
+            "lineage_config_unreadable",
+            f"the parent experiment config {config_path} could not be read",
+        ) from exc
+
+
+def derive_descendant_config(
+    parent_config_path: str | Path,
+    basecall: PublishedRebasecallBasecall,
+    destination: str | Path,
+) -> Path:
+    """Write the descendant's config: the parent's, reading the new calls.
+
+    ``output_directory`` is deliberately *not* overridden. The descendant
+    publishes into the parent experiment's ordinary stage directories, beside
+    the parent's generation, because a lineage is a map ``stage -> generation
+    id`` rather than a second nested run tree.
+    """
+    parent_config_path = Path(parent_config_path)
+    destination = Path(destination)
+    rows = _read_config_rows(parent_config_path)
+    if not rows:
+        raise RebasecallLineageError(
+            "lineage_config_unreadable",
+            f"the parent experiment config {parent_config_path} is empty",
+        )
+    calls_path = basecall.directory / BASECALL_BAM_FILENAME
+    if not calls_path.is_file():
+        raise RebasecallLineageError(
+            "lineage_basecall_missing",
+            "the published basecall has no calls BAM to ingest",
+        )
+
+    header, *body = rows
+    width = len(header)
+    kept = [row for row in body if row and row[0] not in _OVERRIDDEN_CONFIG_FIELDS]
+
+    def _row(variable: str, value: str) -> list[str]:
+        row = [variable, value]
+        row.extend([""] * max(0, width - len(row)))
+        return row
+
+    kept.append(_row("input_data_path", str(calls_path)))
+    kept.append(_row("alignment_mode", "align"))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(kept)
+    return destination
+
+
+def run_lineage_raw_stage(
+    plan: RebasecallPlan,
+    selection: FrozenRebasecallSelection,
+    basecall: PublishedRebasecallBasecall,
+    rebasecall_root: str | Path,
+    *,
+    accepted_plan_id: str,
+    parent_config_path: str | Path,
+    raw_stage_runner: Callable[..., Any] | None = None,
+    identity_map: str | None = None,
+) -> LineageRawStageResult:
+    """Publish one lineage whose descendant raw generation was actually built.
+
+    The raw stage runs inside the lineage transaction, so a stage killed partway
+    leaves the parent run and every prior complete lineage untouched: the
+    descendant generation is never selected, and the lineage never appears.
+    """
+    if raw_stage_runner is None:
+        from ..cli.raw_adata import raw_adata as raw_stage_runner  # noqa: PLC0415
+
+    rebasecall_root = Path(rebasecall_root)
+    identity = build_lineage_identity(plan, selection, basecall)
+    run_root = Path(plan.run_root)
+
+    with staged_lineage(
+        plan,
+        selection,
+        basecall,
+        rebasecall_root,
+        accepted_plan_id=accepted_plan_id,
+    ) as staged:
+        descendant_config = derive_descendant_config(
+            parent_config_path,
+            basecall,
+            staged.staging_dir / DESCENDANT_CONFIG_FILENAME,
+        )
+        provenance = descendant_raw_provenance(
+            staged.lineage_id,
+            identity,
+            basecall,
+            identity_map=identity_map,
+        )
+        result = raw_stage_runner(str(descendant_config), lineage_provenance=provenance)
+        generation_id = _descendant_generation_id(result)
+        staged.record_stage_generation("raw", generation_id)
+        final_dir = staged.final_dir
+
+    lineage = read_published_rebasecall_lineage(final_dir, expected_lineage_id=staged.lineage_id)
+    return LineageRawStageResult(
+        lineage=lineage,
+        raw_generation_id=generation_id,
+        descendant_config_path=lineage.directory / DESCENDANT_CONFIG_FILENAME,
+        run_root=run_root,
+    )
+
+
+def _descendant_generation_id(result: Any) -> str:
+    """Recover the published generation id from a raw-stage result."""
+    if isinstance(result, Mapping) and "generation_id" in result:
+        return str(result["generation_id"])
+    if isinstance(result, (tuple, list)) and len(result) >= 2:
+        generation_spine = Path(str(result[1]))
+        # ``<raw_outputs>/generations/<id>/spine.h5ad``
+        if generation_spine.name == "spine.h5ad" and generation_spine.parent.parent.name == (
+            "generations"
+        ):
+            return generation_spine.parent.name
+    raise RebasecallLineageError(
+        "lineage_raw_stage_unrecognized",
+        "the raw stage did not report a published generation",
+    )

--- a/tests/integration/informatics/test_lineage_raw_stage_publication.py
+++ b/tests/integration/informatics/test_lineage_raw_stage_publication.py
@@ -1,0 +1,151 @@
+"""The descendant raw stage, run for real, publishes beside the parent.
+
+The unit coverage for `SRB-05b` drives the raw stage through an injected runner.
+This exercises the actual `raw_adata` publication path, because the hazard this
+program keeps rediscovering is that a seam looks right until something really
+runs through it.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from array import array
+from pathlib import Path
+
+import pytest
+
+from smftools.cli.raw_adata import raw_adata
+from smftools.informatics.raw_generation import (
+    resolve_current_raw_generation,
+    validate_raw_generation,
+)
+
+pysam = pytest.importorskip("pysam")
+pytestmark = pytest.mark.integration
+
+_LINEAGE_PROVENANCE = {
+    "lineage_id": "a" * 64,
+    "origin_experiment_uid": "uid-a",
+    "parent_raw_generation_id": "parent-a",
+    "parent_preprocess_generation_id": None,
+    "selection_id": "b" * 64,
+    "source_resolution_digest": None,
+    "basecall_id": "c" * 64,
+    "generation_kind": "selected_cohort",
+    "identity_map": None,
+}
+
+
+def _write_aligned_bam(path: Path) -> None:
+    header = {
+        "HD": {"VN": "1.6", "SO": "coordinate"},
+        "SQ": [{"SN": "ref", "LN": 12}],
+        "PG": [{"ID": "external", "PN": "external-aligner", "VN": "1"}],
+    }
+    with pysam.AlignmentFile(str(path), "wb", header=header) as bam:
+        read = pysam.AlignedSegment()
+        read.query_name = "read-1"
+        read.query_sequence = "ACGT"
+        read.query_qualities = pysam.qualitystring_to_array("IIII")
+        read.reference_id = 0
+        read.reference_start = 0
+        read.cigarstring = "4M"
+        read.mapping_quality = 60
+        read.set_tag("BC", "barcode01")
+        read.set_tag("MM", "C+m,0;")
+        read.set_tag("ML", array("B", [200]))
+        bam.write(read)
+    pysam.index(str(path))
+
+
+def _write_config(path: Path, *, bam_path: Path, fasta: Path, run_root: Path) -> Path:
+    rows = [
+        ("variable", "value", "help", "options", "type"),
+        ("alignment_mode", "existing", "", "", "str"),
+        ("input_data_path", str(bam_path), "", "", "str"),
+        ("output_directory", str(run_root), "", "", "str"),
+        ("fasta", str(fasta), "", "", "str"),
+        ("experiment_id", "existing-direct", "", "", "str"),
+        ("experiment_name", "existing-direct", "", "", "str"),
+        ("smf_modality", "direct", "", "", "str"),
+        ("direct_signal_backend", "pysam", "", "", "str"),
+        ("input_already_demuxed", "True", "", "", "bool"),
+        ("skip_bam_split", "True", "", "", "bool"),
+        ("skip_bam_qc", "True", "", "", "bool"),
+        ("threads", "1", "", "", "int"),
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        csv.writer(handle).writerows(rows)
+    return path
+
+
+def test_a_descendant_publishes_beside_the_parent_without_taking_current(tmp_path, monkeypatch):
+    fasta = tmp_path / "reference.fa"
+    fasta.write_text(">ref\nACGTACGTACGT\n", encoding="utf-8")
+    parent_bam = tmp_path / "parent.bam"
+    _write_aligned_bam(parent_bam)
+    run_root = tmp_path / "run"
+    parent_config = _write_config(
+        tmp_path / "parent_config.csv",
+        bam_path=parent_bam,
+        fasta=fasta,
+        run_root=run_root,
+    )
+    monkeypatch.setattr(
+        "smftools.informatics.bam_functions.align_and_sort_BAM",
+        lambda *_args, **_kwargs: pytest.fail("existing mode invoked an aligner"),
+    )
+
+    raw_adata(str(parent_config))
+    parent_dir, parent_manifest = resolve_current_raw_generation(run_root / "raw_outputs")
+
+    descendant_bam = tmp_path / "calls.bam"
+    _write_aligned_bam(descendant_bam)
+    descendant_config = _write_config(
+        tmp_path / "descendant_config.csv",
+        bam_path=descendant_bam,
+        fasta=fasta,
+        run_root=run_root,
+    )
+
+    _, descendant_spine, _ = raw_adata(
+        str(descendant_config),
+        lineage_provenance=dict(_LINEAGE_PROVENANCE),
+    )
+
+    descendant_dir = Path(descendant_spine).parent
+    still_current, still_manifest = resolve_current_raw_generation(run_root / "raw_outputs")
+    descendant = validate_raw_generation(descendant_dir, run_root=run_root)
+
+    # Both generations exist; the parent is still what ordinary readers resolve.
+    assert descendant_dir != parent_dir
+    assert still_current == parent_dir
+    assert still_manifest["generation_id"] == parent_manifest["generation_id"]
+    assert descendant["lineage"] == _LINEAGE_PROVENANCE
+    assert descendant["schema_version"] == 3
+    pointer = json.loads((run_root / "raw_outputs" / "current.json").read_text(encoding="utf-8"))
+    assert pointer["generation_id"] == parent_manifest["generation_id"]
+
+
+def test_the_parent_generation_records_no_lineage(tmp_path, monkeypatch):
+    fasta = tmp_path / "reference.fa"
+    fasta.write_text(">ref\nACGTACGTACGT\n", encoding="utf-8")
+    bam_path = tmp_path / "parent.bam"
+    _write_aligned_bam(bam_path)
+    run_root = tmp_path / "run"
+    config = _write_config(
+        tmp_path / "config.csv",
+        bam_path=bam_path,
+        fasta=fasta,
+        run_root=run_root,
+    )
+    monkeypatch.setattr(
+        "smftools.informatics.bam_functions.align_and_sort_BAM",
+        lambda *_args, **_kwargs: pytest.fail("existing mode invoked an aligner"),
+    )
+
+    raw_adata(str(config))
+
+    generation_dir, _ = resolve_current_raw_generation(run_root / "raw_outputs")
+    assert validate_raw_generation(generation_dir, run_root=run_root)["lineage"] is None

--- a/tests/unit/pipeline/test_rebasecall_run.py
+++ b/tests/unit/pipeline/test_rebasecall_run.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+from tests.unit.pipeline.test_rebasecall_basecall import _case, _execute, _FakeDorado
+
+from smftools.pipeline.rebasecall_basecall import BASECALL_BAM_FILENAME
+from smftools.pipeline.rebasecall_lineage import (
+    LINEAGE_STAGING_SUBDIR,
+    LINEAGES_SUBDIR,
+    RebasecallLineageError,
+    list_published_rebasecall_lineages,
+)
+from smftools.pipeline.rebasecall_run import (
+    DESCENDANT_CONFIG_FILENAME,
+    derive_descendant_config,
+    run_lineage_raw_stage,
+)
+
+pytestmark = pytest.mark.unit
+
+_PARENT_CONFIG_ROWS = (
+    ("variable", "value", "help", "options", "type"),
+    ("smf_modality", "direct", "Modality of SMF.", "", "str"),
+    ("input_data_path", "/parent/reads.pod5", "Input path", "", "str"),
+    ("alignment_mode", "existing", "Alignment mode", "", "str"),
+    ("fasta", "/refs/genome.fa", "Reference", "", "str"),
+    ("output_directory", "/runs/experiment-a", "Output root", "", "str"),
+    ("hmm_n_states", "3", "States", "", "int"),
+)
+
+
+def _write_parent_config(tmp_path: Path) -> Path:
+    path = tmp_path / "experiment_config.csv"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        csv.writer(handle).writerows(_PARENT_CONFIG_ROWS)
+    return path
+
+
+def _config_values(path: Path) -> dict[str, str]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        rows = [row for row in csv.reader(handle) if row]
+    return {row[0]: row[1] for row in rows[1:]}
+
+
+def _lineage_case(tmp_path, monkeypatch):
+    _, _, plan, frozen = _case(tmp_path, monkeypatch)
+    basecall = _execute(plan, frozen, tmp_path / "basecalls", _FakeDorado())
+    return plan, frozen, basecall
+
+
+def test_descendant_config_reads_the_new_calls_and_inherits_everything_else(tmp_path, monkeypatch):
+    _, _, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+
+    derived = derive_descendant_config(parent, basecall, tmp_path / "derived.csv")
+
+    values = _config_values(derived)
+    assert values["input_data_path"] == str(basecall.directory / BASECALL_BAM_FILENAME)
+    assert values["alignment_mode"] == "align"
+    # The descendant publishes beside the parent, so the run root is inherited.
+    assert values["output_directory"] == "/runs/experiment-a"
+    assert values["smf_modality"] == "direct"
+    assert values["fasta"] == "/refs/genome.fa"
+    assert values["hmm_n_states"] == "3"
+
+
+def test_a_basecall_without_calls_cannot_derive_a_config(tmp_path, monkeypatch):
+    _, _, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+    (basecall.directory / BASECALL_BAM_FILENAME).unlink()
+
+    with pytest.raises(RebasecallLineageError) as error:
+        derive_descendant_config(parent, basecall, tmp_path / "derived.csv")
+
+    assert error.value.code == "lineage_basecall_missing"
+
+
+def test_the_raw_stage_runs_inside_the_lineage_and_is_recorded(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+    root = tmp_path / "rebasecall_outputs"
+    seen: list[dict[str, object]] = []
+
+    def runner(config_path, *, lineage_provenance):
+        seen.append(
+            {
+                "config": _config_values(Path(config_path)),
+                "provenance": dict(lineage_provenance),
+            }
+        )
+        return (
+            None,
+            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
+            None,
+        )
+
+    result = run_lineage_raw_stage(
+        plan,
+        frozen,
+        basecall,
+        root,
+        accepted_plan_id=plan.plan_id,
+        parent_config_path=parent,
+        raw_stage_runner=runner,
+    )
+
+    assert result.raw_generation_id == "descendant-a"
+    assert result.lineage.stage_generations == {"raw": "descendant-a"}
+    assert len(seen) == 1
+    assert seen[0]["config"]["input_data_path"] == str(basecall.directory / BASECALL_BAM_FILENAME)
+    # Per D2 the descendant derives its kind from the basecall it was built from.
+    assert seen[0]["provenance"]["generation_kind"] == basecall.generation_kind
+    assert seen[0]["provenance"]["basecall_id"] == basecall.basecall_id
+    assert seen[0]["provenance"]["lineage_id"] == result.lineage.lineage_id
+    assert (result.lineage.directory / DESCENDANT_CONFIG_FILENAME).is_file()
+    assert result.descendant_config_path.is_file()
+
+
+def test_the_result_payload_follows_the_workflow_contract(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+
+    result = run_lineage_raw_stage(
+        plan,
+        frozen,
+        basecall,
+        tmp_path / "rebasecall_outputs",
+        accepted_plan_id=plan.plan_id,
+        parent_config_path=parent,
+        raw_stage_runner=lambda config_path, *, lineage_provenance: (
+            None,
+            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
+            None,
+        ),
+    )
+
+    payload = result.to_dict()
+
+    assert payload["lineage_id"] == result.lineage.lineage_id
+    assert payload["basecall_id"] == basecall.basecall_id
+    assert payload["stage_generations"] == {"raw": "descendant-a"}
+    assert payload["raw_generation_id"] == "descendant-a"
+    assert Path(payload["run_root"]) == Path(plan.run_root)
+
+
+def test_a_killed_raw_stage_publishes_no_lineage(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+    root = tmp_path / "rebasecall_outputs"
+
+    def killed(config_path, *, lineage_provenance):
+        raise RuntimeError("raw stage was killed")
+
+    with pytest.raises(RuntimeError, match="raw stage was killed"):
+        run_lineage_raw_stage(
+            plan,
+            frozen,
+            basecall,
+            root,
+            accepted_plan_id=plan.plan_id,
+            parent_config_path=parent,
+            raw_stage_runner=killed,
+        )
+
+    assert list_published_rebasecall_lineages(root) == ()
+    assert not any((root / LINEAGE_STAGING_SUBDIR).iterdir())
+    assert not (root / LINEAGES_SUBDIR).exists() or not any((root / LINEAGES_SUBDIR).iterdir())
+
+
+def test_a_raw_stage_that_reports_no_generation_is_an_error(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+    root = tmp_path / "rebasecall_outputs"
+
+    with pytest.raises(RebasecallLineageError) as error:
+        run_lineage_raw_stage(
+            plan,
+            frozen,
+            basecall,
+            root,
+            accepted_plan_id=plan.plan_id,
+            parent_config_path=parent,
+            raw_stage_runner=lambda config_path, *, lineage_provenance: None,
+        )
+
+    assert error.value.code == "lineage_raw_stage_unrecognized"
+    assert list_published_rebasecall_lineages(root) == ()
+
+
+def test_a_relocated_lineage_still_validates(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    parent = _write_parent_config(tmp_path)
+    root = tmp_path / "rebasecall_outputs"
+    result = run_lineage_raw_stage(
+        plan,
+        frozen,
+        basecall,
+        root,
+        accepted_plan_id=plan.plan_id,
+        parent_config_path=parent,
+        raw_stage_runner=lambda config_path, *, lineage_provenance: (
+            None,
+            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
+            None,
+        ),
+    )
+
+    relocated = tmp_path / "moved_outputs"
+    root.rename(relocated)
+    moved = list_published_rebasecall_lineages(relocated)
+
+    # Lineage identity is path-neutral, so moving the container preserves it.
+    assert [item.lineage_id for item in moved] == [result.lineage.lineage_id]
+    assert moved[0].stage_generations == {"raw": "descendant-a"}


### PR DESCRIPTION
`SRB-05a` can publish a lineage, but only from generation ids a caller already had. Nothing built one: the raw stage had no way to publish a descendant, and no way to publish anything without also making it current.

Give `raw_adata` a `lineage_provenance` keyword. A descendant run publishes beside the parent's generation without advancing `current.json`, and takes neither the completeness skip nor the append path -- a selected cohort is not a later state of the parent's source universe, so appending onto it or skipping because the parent looks complete would both be wrong.

Add `pipeline/rebasecall_run.py`. `derive_descendant_config` writes the parent's config reading the new `calls.bam`; every other field is inherited verbatim, because a lineage re-runs the *same* experiment against new calls and silently changing a reference or threshold would make the comparison meaningless. `output_directory` is deliberately not overridden: the descendant belongs in the parent experiment's ordinary stage directories, which is what makes a lineage a map `stage -> generation id` rather than a second nested run tree.

`run_lineage_raw_stage` runs the stage *inside* the lineage transaction, so the exit gate holds through the real work and not just around it: a killed raw stage publishes no lineage, leaves no staging, and leaves the parent current. `LineageRawStageResult.to_dict()` is the engine-facing workflow payload.

Note the lane's original wording -- "stage an ordinary experiment run beneath a unique lineage root" -- predates the artifact layout that dropped the nested `run/` subtree. The layout is followed here; the lineage records ids.

Validated against the real stage, not only an injected runner: two integration tests drive `raw_adata` itself and confirm a descendant publishes beside its parent with `current.json` untouched and schema 3 carrying the lineage block, while an ordinary generation records none. That seam is exactly where this program has twice found problems that unit tests could not.

7 focused unit tests; full unit suite 2,055 passed, 8 skipped, 181 deselected, 7 xfailed; 55 integration (up from 53), 106 smoke, 19 e2e; Ruff check/format and Sphinx `-W` clean.