### PR TITLE
feat: run descendant downstream stages inside the lineage

### DIFF
--- a/src/smftools/cli/helpers.py
+++ b/src/smftools/cli/helpers.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 import anndata as ad
 
@@ -439,17 +439,27 @@ def partitioned_stage_is_complete(
     )
 
 
-def get_adata_paths(cfg, *, allow_invalid_raw: bool = False) -> AdataPaths:
+def get_adata_paths(
+    cfg,
+    *,
+    allow_invalid_raw: bool = False,
+    lineage_generations: Mapping[str, str] | None = None,
+) -> AdataPaths:
     """Compute all standard AnnData paths for an experiment.
 
     Args:
         cfg: Loaded experiment configuration.
         allow_invalid_raw: Fall back to the legacy raw spine when the current
             generation selector is invalid. Reserved for raw-stage recovery.
+        lineage_generations: Optional ``stage -> generation id`` map pinning
+            which generation each stage resolves. This is the `D1` selector: a
+            re-basecalling lineage reads its own descendant generations while
+            ``current.json`` keeps answering for everyone else.
 
     Returns:
         The canonical and generation-selected artifact paths.
     """
+    lineage_generations = dict(lineage_generations or {})
     output_directory = Path(cfg.output_directory)
 
     # Raw and Preprocessed adata file pathes will have set names.
@@ -483,23 +493,38 @@ def get_adata_paths(cfg, *, allow_invalid_raw: bool = False) -> AdataPaths:
     spine = load_dir / "spine.h5ad"
     catalog = load_dir / "catalog.parquet"
     raw_output_dir = output_directory / RAW_DIR
+    from ..informatics.generation import resolve_stage_generation
     from ..informatics.raw_generation import RawGenerationError, resolve_current_raw_generation
 
-    try:
-        current_raw_generation = resolve_current_raw_generation(raw_output_dir)
-    except RawGenerationError:
-        if not allow_invalid_raw:
-            raise
+    def _stage_spine(stage: str, stage_dir: Path) -> Path:
+        """Resolve one stage's spine, honouring a lineage pin when present."""
+        pinned = lineage_generations.get(stage)
+        if pinned is None:
+            return stage_dir / "spine.h5ad"
+        resolved = resolve_stage_generation(stage_dir, pinned)
+        if resolved is None:
+            raise RawGenerationError(f"{stage} lineage generation {pinned!r} could not be resolved")
+        return resolved[0] / "spine.h5ad"
+
+    if "raw" in lineage_generations:
         current_raw_generation = None
-    raw_spine = (
-        current_raw_generation[0] / "spine.h5ad"
-        if current_raw_generation is not None
-        else raw_output_dir / "spine.h5ad"
-    )
-    preprocess_spine = output_directory / PREPROCESS_DIR / "spine.h5ad"
-    spatial_spine = output_directory / SPATIAL_DIR / "spine.h5ad"
-    hmm_spine = output_directory / HMM_DIR / "spine.h5ad"
-    latent_spine = output_directory / LATENT_DIR / "spine.h5ad"
+        raw_spine = _stage_spine("raw", raw_output_dir)
+    else:
+        try:
+            current_raw_generation = resolve_current_raw_generation(raw_output_dir)
+        except RawGenerationError:
+            if not allow_invalid_raw:
+                raise
+            current_raw_generation = None
+        raw_spine = (
+            current_raw_generation[0] / "spine.h5ad"
+            if current_raw_generation is not None
+            else raw_output_dir / "spine.h5ad"
+        )
+    preprocess_spine = _stage_spine("preprocess", output_directory / PREPROCESS_DIR)
+    spatial_spine = _stage_spine("spatial", output_directory / SPATIAL_DIR)
+    hmm_spine = _stage_spine("hmm", output_directory / HMM_DIR)
+    latent_spine = _stage_spine("latent", output_directory / LATENT_DIR)
 
     return AdataPaths(
         raw=raw,

--- a/src/smftools/cli/preprocess_adata.py
+++ b/src/smftools/cli/preprocess_adata.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import gc
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 import anndata as ad
 
@@ -27,9 +27,16 @@ def preprocess_adata(
     config_path: str,
     *,
     cfg=None,
+    lineage_generations: Mapping[str, str] | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
 ) -> Tuple[Optional[Path], Optional[Path]]:
     """
     CLI-facing wrapper for preprocessing.
+
+    ``lineage_generations`` pins which generation each upstream stage resolves,
+    and ``lineage_provenance`` marks the published result as a re-basecalled
+    descendant. Together they let a lineage preprocess its own descendant raw
+    generation while ``current.json`` keeps answering for everyone else.
 
     Called by: `smftools experiment preprocess <config_path>`
 
@@ -64,8 +71,13 @@ def preprocess_adata(
     if getattr(cfg, "output_directory", None) is not None:
         setup_stage_logging(cfg, Path(cfg.output_directory) / PREPROCESS_DIR)
 
-    # 2) Compute canonical paths
-    paths = get_adata_paths(cfg)
+    # 2) Compute canonical paths. Only a lineage run passes a pin, so the
+    # ordinary call is unchanged for every other caller and test double.
+    paths = (
+        get_adata_paths(cfg, lineage_generations=lineage_generations)
+        if lineage_generations
+        else get_adata_paths(cfg)
+    )
     raw_path = paths.raw
     pp_path = paths.pp
     pp_dedup_path = paths.pp_dedup
@@ -107,9 +119,21 @@ def preprocess_adata(
         )
 
         output_dir = Path(cfg.output_directory) / PREPROCESS_DIR
+        # Only a lineage run publishes a non-selected descendant, so the
+        # ordinary call keeps its existing signature.
+        lineage_kwargs = (
+            {"lineage_provenance": lineage_provenance, "select_current": False}
+            if lineage_provenance is not None
+            else {}
+        )
         with stage_lifecycle(cfg, "preprocess", source_path) as lifecycle:
             with perf_substep("partitioned_preprocess"):
-                outputs = publish_preprocess_generation(source_path, cfg, output_dir)
+                outputs = publish_preprocess_generation(
+                    source_path,
+                    cfg,
+                    output_dir,
+                    **lineage_kwargs,
+                )
             publish_stage_outputs(
                 lifecycle,
                 outputs,

--- a/src/smftools/informatics/generation.py
+++ b/src/smftools/informatics/generation.py
@@ -81,6 +81,64 @@ def _current_path(output_dir: Path) -> Path:
     return output_dir / CURRENT_FILENAME
 
 
+# One generation kind can be a re-basecalled descendant of another. The block is
+# optional and its absence is meaningful: an ordinary generation has no lineage
+# provenance and a reader must not invent one. Per `D2` in the
+# generation-lifecycle plan, ``generation_kind`` is *derived* from the basecall
+# generation rather than independently asserted by each descendant stage.
+LINEAGE_PROVENANCE_KEYS = frozenset(
+    {
+        "lineage_id",
+        "origin_experiment_uid",
+        "parent_raw_generation_id",
+        "parent_preprocess_generation_id",
+        "selection_id",
+        "source_resolution_digest",
+        "basecall_id",
+        "generation_kind",
+        "identity_map",
+    }
+)
+LINEAGE_GENERATION_KINDS = frozenset({"full_source", "parent_universe", "selected_cohort"})
+_LINEAGE_REQUIRED_TEXT_KEYS = (
+    "lineage_id",
+    "origin_experiment_uid",
+    "parent_raw_generation_id",
+    "selection_id",
+    "basecall_id",
+    "generation_kind",
+)
+_LINEAGE_OPTIONAL_TEXT_KEYS = (
+    "parent_preprocess_generation_id",
+    "source_resolution_digest",
+    "identity_map",
+)
+
+
+def validate_lineage_provenance(lineage: Any) -> dict[str, Any] | None:
+    """Validate a generation's lineage block, if it carries one.
+
+    Returns ``None`` for an ordinary generation. A malformed block is an error
+    rather than a warning: a descendant that cannot state which selection and
+    basecall produced it is exactly the artifact this program exists to prevent.
+    """
+    if lineage is None:
+        return None
+    if not isinstance(lineage, dict) or set(lineage) != LINEAGE_PROVENANCE_KEYS:
+        raise GenerationError("generation lineage provenance is malformed")
+    for key in _LINEAGE_REQUIRED_TEXT_KEYS:
+        value = lineage.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise GenerationError(f"generation lineage provenance lacks {key}")
+    if lineage["generation_kind"] not in LINEAGE_GENERATION_KINDS:
+        raise GenerationError("generation lineage generation kind is invalid")
+    for key in _LINEAGE_OPTIONAL_TEXT_KEYS:
+        value = lineage.get(key)
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise GenerationError(f"generation lineage provenance has an invalid {key}")
+    return lineage
+
+
 @contextmanager
 def staged_generation(
     output_dir: str | Path,
@@ -90,6 +148,7 @@ def staged_generation(
     generation_id: str | None = None,
     manifest_checksum: Callable[[Path], str] | None = None,
     write_json: Callable[[str | Path, Any], None] | None = None,
+    after_publish: Callable[[Path, Path, Path], None] | None = None,
     after_current: Callable[[Path, Path, Path], None] | None = None,
     select_current: bool = True,
 ) -> Iterator[StagedGeneration]:
@@ -111,9 +170,18 @@ def staged_generation(
             rollback. Defaults to :func:`smftools.readwrite.atomic_write_json`.
             Kind-specific callers may pass their imported writer to preserve
             failure-injection seams.
+        after_publish: Optional ``(staging_dir, final_dir, run_root)`` callable
+            run after the tree moves and *before* the selector advances, whether
+            or not it will. Use it for work that describes the generation itself,
+            such as validating it at its published location. A failure removes
+            the new generation and leaves the selector untouched.
         after_current: Optional ``(staging_dir, final_dir, run_root)`` callable
-            run after the selector advances. A failure restores the previous
-            selector and removes the new generation.
+            run only when the selector actually advances. Use it for work that
+            follows *selection* rather than publication -- publishing a canonical
+            stage-root spine, for instance, which ordinary readers resolve and
+            which a non-selected generation must therefore never overwrite. A
+            failure restores the previous selector and removes the new
+            generation.
         select_current: Whether publication also advances ``current.json``.
             Set ``False`` to publish without selecting, which is how a
             re-basecalling lineage adds a descendant generation beside the
@@ -175,6 +243,8 @@ def staged_generation(
             validate(staging_dir, final_dir, run_root)
         os.replace(staging_dir, final_dir)
         moved = True
+        if after_publish is not None:
+            after_publish(staging_dir, final_dir, run_root)
         if select_current:
             pointer = {
                 "schema_version": CURRENT_SCHEMA_VERSION,
@@ -185,8 +255,8 @@ def staged_generation(
                 pointer["manifest_sha256"] = manifest_checksum(final_dir / GENERATION_MANIFEST)
             write_json(pointer_path, pointer)
             current_advanced = True
-        if after_current is not None:
-            after_current(staging_dir, final_dir, run_root)
+            if after_current is not None:
+                after_current(staging_dir, final_dir, run_root)
     except Exception:
         shutil.rmtree(staging_dir, ignore_errors=True)
         if moved:

--- a/src/smftools/informatics/raw_generation.py
+++ b/src/smftools/informatics/raw_generation.py
@@ -20,10 +20,12 @@ from .generation import (
     CURRENT_SCHEMA_VERSION,
     GENERATION_MANIFEST,
     GENERATIONS_SUBDIR,
+    LINEAGE_PROVENANCE_KEYS,
     STAGING_SUBDIR,
     GenerationError,
     resolve_current_generation,
     staged_generation,
+    validate_lineage_provenance,
 )
 from .partition_read import relative_uns_path, resolve_relative_path
 from .sidecar_manifest import register_sidecar, resolve_sidecar, sidecar_manifest_path
@@ -36,31 +38,10 @@ RAW_GENERATION_SCHEMA_VERSION = 3
 RAW_CURRENT_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION
 
 # Schema 3 adds the optional ``lineage`` block marking a generation as a
-# re-basecalled descendant. Its absence is meaningful: an ordinary generation
-# has no lineage provenance, and a reader must not invent one. Per `D2`,
-# ``generation_kind`` is *derived* from the basecall generation rather than
-# independently asserted here.
-RAW_LINEAGE_PROVENANCE_KEYS = frozenset(
-    {
-        "lineage_id",
-        "origin_experiment_uid",
-        "parent_raw_generation_id",
-        "parent_preprocess_generation_id",
-        "selection_id",
-        "source_resolution_digest",
-        "basecall_id",
-        "generation_kind",
-        "identity_map",
-    }
-)
-_LINEAGE_REQUIRED_TEXT_KEYS = (
-    "lineage_id",
-    "origin_experiment_uid",
-    "parent_raw_generation_id",
-    "selection_id",
-    "basecall_id",
-    "generation_kind",
-)
+# re-basecalled descendant. The shape is shared with every other generation kind
+# that can carry one, so it lives in ``informatics/generation.py``.
+RAW_LINEAGE_PROVENANCE_KEYS = LINEAGE_PROVENANCE_KEYS
+validate_raw_lineage_provenance = validate_lineage_provenance
 
 RAW_GENERATION_ARTIFACT_PATHS: dict[str, str] = {
     "spine": "spine.h5ad",
@@ -253,30 +234,6 @@ def _write_generation_sidecar_manifest(
     return manifest_path
 
 
-def validate_raw_lineage_provenance(lineage: Any) -> dict[str, Any] | None:
-    """Validate a descendant generation's lineage block, if it carries one.
-
-    Returns ``None`` for an ordinary generation. A malformed block is an error
-    rather than a warning: a descendant that cannot state which selection and
-    basecall produced it is exactly the artifact this program exists to prevent.
-    """
-    if lineage is None:
-        return None
-    if not isinstance(lineage, dict) or set(lineage) != RAW_LINEAGE_PROVENANCE_KEYS:
-        raise RawGenerationError("raw generation lineage provenance is malformed")
-    for key in _LINEAGE_REQUIRED_TEXT_KEYS:
-        value = lineage.get(key)
-        if not isinstance(value, str) or not value.strip():
-            raise RawGenerationError(f"raw generation lineage provenance lacks {key}")
-    if lineage["generation_kind"] not in {"full_source", "parent_universe", "selected_cohort"}:
-        raise RawGenerationError("raw generation lineage generation kind is invalid")
-    for key in ("parent_preprocess_generation_id", "source_resolution_digest", "identity_map"):
-        value = lineage.get(key)
-        if value is not None and (not isinstance(value, str) or not value.strip()):
-            raise RawGenerationError(f"raw generation lineage provenance has an invalid {key}")
-    return lineage
-
-
 def validate_raw_generation(
     generation_dir: str | Path,
     *,
@@ -294,7 +251,10 @@ def validate_raw_generation(
     generation_schema = int(manifest.get("schema_version", -1))
     if generation_schema not in {1, 2, RAW_GENERATION_SCHEMA_VERSION}:
         raise RawGenerationError("raw generation schema is incompatible")
-    validate_raw_lineage_provenance(manifest.get("lineage"))
+    try:
+        validate_lineage_provenance(manifest.get("lineage"))
+    except GenerationError as exc:
+        raise RawGenerationError(f"raw {exc}") from exc
     if manifest.get("status") != "complete":
         raise RawGenerationError("raw generation is not complete")
     generation_id = str(manifest.get("generation_id", ""))
@@ -445,9 +405,12 @@ def publish_raw_generation(
     """
     run_root = Path(run_root)
     raw_output_dir = run_root / "raw_outputs"
-    lineage = validate_raw_lineage_provenance(
-        dict(lineage_provenance) if lineage_provenance is not None else None
-    )
+    try:
+        lineage = validate_lineage_provenance(
+            dict(lineage_provenance) if lineage_provenance is not None else None
+        )
+    except GenerationError as exc:
+        raise RawGenerationError(f"raw {exc}") from exc
     reuse_root = Path(reuse_generation) if reuse_generation is not None else None
     reuse_manifest: dict[str, Any] | None = None
     if reuse_root is not None:
@@ -502,7 +465,10 @@ def publish_raw_generation(
             generation_id=generation_id,
             manifest_checksum=_checksum,
             write_json=atomic_write_json,
-            after_current=validate_published,
+            # Validating the published tree describes the generation, not the
+            # selection, so a descendant that never becomes current is validated
+            # at its final location just as a selected one is.
+            after_publish=validate_published,
             select_current=select_current,
         ) as staged:
             generation_id = staged.generation_id

--- a/src/smftools/pipeline/rebasecall_run.py
+++ b/src/smftools/pipeline/rebasecall_run.py
@@ -114,16 +114,25 @@ def run_lineage_raw_stage(
     accepted_plan_id: str,
     parent_config_path: str | Path,
     raw_stage_runner: Callable[..., Any] | None = None,
+    preprocess_stage_runner: Callable[..., Any] | None = None,
     identity_map: str | None = None,
 ) -> LineageRawStageResult:
-    """Publish one lineage whose descendant raw generation was actually built.
+    """Publish one lineage whose descendant generations were actually built.
 
-    The raw stage runs inside the lineage transaction, so a stage killed partway
-    leaves the parent run and every prior complete lineage untouched: the
-    descendant generation is never selected, and the lineage never appears.
+    Every stage runs inside the lineage transaction, so a stage killed partway
+    leaves the parent run and every prior complete lineage untouched: no
+    descendant generation is ever selected, and the lineage never appears.
+
+    How far this runs is the accepted request's ``downstream.target``. A target
+    of ``raw`` stops after raw; anything deeper also preprocesses, reading the
+    descendant raw generation rather than whatever the parent currently selects.
     """
     if raw_stage_runner is None:
         from ..cli.raw_adata import raw_adata as raw_stage_runner  # noqa: PLC0415
+    if preprocess_stage_runner is None:
+        from ..cli.preprocess_adata import (  # noqa: PLC0415
+            preprocess_adata as preprocess_stage_runner,
+        )
 
     rebasecall_root = Path(rebasecall_root)
     identity = build_lineage_identity(plan, selection, basecall)
@@ -150,6 +159,16 @@ def run_lineage_raw_stage(
         result = raw_stage_runner(str(descendant_config), lineage_provenance=provenance)
         generation_id = _descendant_generation_id(result)
         staged.record_stage_generation("raw", generation_id)
+        if plan.request.downstream_target != "raw":
+            preprocess_result = preprocess_stage_runner(
+                str(descendant_config),
+                lineage_generations={"raw": generation_id},
+                lineage_provenance=provenance,
+            )
+            staged.record_stage_generation(
+                "preprocess",
+                _descendant_generation_id(preprocess_result),
+            )
         final_dir = staged.final_dir
 
     lineage = read_published_rebasecall_lineage(final_dir, expected_lineage_id=staged.lineage_id)
@@ -162,17 +181,23 @@ def run_lineage_raw_stage(
 
 
 def _descendant_generation_id(result: Any) -> str:
-    """Recover the published generation id from a raw-stage result."""
+    """Recover the published generation id from one stage's result.
+
+    Stages report their published spine in different result positions, so the
+    generation is identified by the published *shape*
+    (``<stage>/generations/<id>/spine.h5ad``) rather than by a per-stage
+    convention that would silently drift.
+    """
     if isinstance(result, Mapping) and "generation_id" in result:
         return str(result["generation_id"])
-    if isinstance(result, (tuple, list)) and len(result) >= 2:
-        generation_spine = Path(str(result[1]))
-        # ``<raw_outputs>/generations/<id>/spine.h5ad``
-        if generation_spine.name == "spine.h5ad" and generation_spine.parent.parent.name == (
-            "generations"
-        ):
-            return generation_spine.parent.name
+    candidates = result if isinstance(result, (tuple, list)) else (result,)
+    for candidate in candidates:
+        if not isinstance(candidate, (str, Path)):
+            continue
+        spine = Path(str(candidate))
+        if spine.name == "spine.h5ad" and spine.parent.parent.name == "generations":
+            return spine.parent.name
     raise RebasecallLineageError(
         "lineage_raw_stage_unrecognized",
-        "the raw stage did not report a published generation",
+        "the stage did not report a published generation",
     )

--- a/src/smftools/preprocessing/preprocess_generation.py
+++ b/src/smftools/preprocessing/preprocess_generation.py
@@ -6,7 +6,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 from uuid import uuid4
 
 import pandas as pd
@@ -24,6 +24,7 @@ from ..informatics.generation import (
     GenerationError,
     resolve_current_generation,
     staged_generation,
+    validate_lineage_provenance,
 )
 from ..informatics.partition_read import load_spine, relative_uns_path
 from ..informatics.sidecar_manifest import resolve_sidecar, sidecar_manifest_path
@@ -265,6 +266,10 @@ def validate_preprocess_generation(
         raise PreprocessGenerationError("preprocess generation schema is incompatible")
     if manifest.get("status") != "complete":
         raise PreprocessGenerationError("preprocess generation is not complete")
+    try:
+        validate_lineage_provenance(manifest.get("lineage"))
+    except GenerationError as exc:
+        raise PreprocessGenerationError(f"preprocess {exc}") from exc
     generation_id = str(manifest.get("generation_id", ""))
     if not generation_id or (
         expected_generation_id is not None and generation_id != expected_generation_id
@@ -497,8 +502,16 @@ def publish_preprocess_generation(
     output_dir: str | Path,
     *,
     executor: Callable[..., dict[str, Path]] | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
+    select_current: bool = True,
 ) -> dict[str, Path | str | int]:
-    """Build, validate, and atomically select one immutable preprocess generation."""
+    """Build, validate, and atomically publish one immutable preprocess generation.
+
+    ``lineage_provenance`` marks the result as a re-basecalled descendant.
+    Publishing one with ``select_current=False`` also leaves the canonical
+    stage-root spine untouched, because that file is what ordinary readers
+    resolve and a non-selected generation must never become their answer.
+    """
     from ..cli.helpers import stage_config_hash
     from ..informatics.experiment_spine import write_experiment_spine
     from .partitioned_executor import execute_partitioned_preprocessing
@@ -512,6 +525,12 @@ def publish_preprocess_generation(
         preprocess_force_targets,
     )
 
+    try:
+        lineage_provenance = validate_lineage_provenance(
+            dict(lineage_provenance) if lineage_provenance is not None else None
+        )
+    except GenerationError as exc:
+        raise PreprocessGenerationError(f"preprocess {exc}") from exc
     spine_path = Path(spine_path)
     output_dir = Path(output_dir)
     run_root = output_dir.parent
@@ -553,6 +572,7 @@ def publish_preprocess_generation(
             manifest_checksum=_checksum,
             write_json=atomic_write_json,
             after_current=publish_spine,
+            select_current=select_current,
         ) as staged:
             generation_id = staged.generation_id
             staging_dir = staged.staging_dir
@@ -640,6 +660,9 @@ def publish_preprocess_generation(
                     "task_count": task_count,
                     "upgrade_plan": upgrade_plan.to_dict(),
                     "node_results": [result.to_dict() for result in node_results],
+                    "lineage": (
+                        dict(lineage_provenance) if lineage_provenance is not None else None
+                    ),
                     "artifacts": artifacts,
                 }
             )

--- a/tests/unit/informatics/test_generation.py
+++ b/tests/unit/informatics/test_generation.py
@@ -254,3 +254,35 @@ def test_unreadable_pointer_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(GenerationError, match="unreadable"):
         resolve_current_generation(out)
+
+
+def test_publishing_without_selecting_leaves_the_pointer_and_selection_hooks_alone(
+    tmp_path: Path,
+) -> None:
+    """A descendant is addressable immediately, but answers for nobody yet."""
+    out = tmp_path / "preprocess_adata_outputs"
+    first = _publish(out)
+    after_publish: list[str] = []
+    after_current: list[str] = []
+
+    with staged_generation(
+        out,
+        generation_id="descendant",
+        after_publish=lambda _staging, final, _root: after_publish.append(final.name),
+        after_current=lambda _staging, final, _root: after_current.append(final.name),
+        select_current=False,
+    ) as staged:
+        staged.record_manifest({"status": "complete"})
+
+    generation_dir, manifest = resolve_current_generation(out)
+
+    # The descendant exists on disk and is fully published...
+    assert (out / GENERATIONS_SUBDIR / "descendant" / GENERATION_MANIFEST).is_file()
+    # ...but the previous generation is still what ordinary readers resolve.
+    assert manifest["generation_id"] == first
+    assert generation_dir.name == first
+    # Work that describes the generation runs; work that follows *selection*
+    # does not, which is what keeps a non-selected generation from overwriting a
+    # canonical stage-root spine.
+    assert after_publish == ["descendant"]
+    assert after_current == []

--- a/tests/unit/pipeline/test_rebasecall_run.py
+++ b/tests/unit/pipeline/test_rebasecall_run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -45,10 +46,25 @@ def _config_values(path: Path) -> dict[str, str]:
     return {row[0]: row[1] for row in rows[1:]}
 
 
-def _lineage_case(tmp_path, monkeypatch):
-    _, _, plan, frozen = _case(tmp_path, monkeypatch)
+def _lineage_case(tmp_path, monkeypatch, *, mode="all-parent-molecules"):
+    _, _, plan, frozen = _case(tmp_path, monkeypatch, mode=mode)
     basecall = _execute(plan, frozen, tmp_path / "basecalls", _FakeDorado())
     return plan, frozen, basecall
+
+
+def _spine(tmp_path, stage, generation_id):
+    return tmp_path / stage / "generations" / generation_id / "spine.h5ad"
+
+
+def _stage_runner(tmp_path, stage, generation_id, *, record=None):
+    def runner(config_path, **kwargs):
+        if record is not None:
+            # Read the config here: it lives in the lineage staging tree, which
+            # is gone by the time the caller inspects the result.
+            record.append({"config": _config_values(Path(config_path)), **kwargs})
+        return (_spine(tmp_path, stage, generation_id), None)
+
+    return runner
 
 
 def test_descendant_config_reads_the_new_calls_and_inherits_everything_else(tmp_path, monkeypatch):
@@ -78,24 +94,12 @@ def test_a_basecall_without_calls_cannot_derive_a_config(tmp_path, monkeypatch):
     assert error.value.code == "lineage_basecall_missing"
 
 
-def test_the_raw_stage_runs_inside_the_lineage_and_is_recorded(tmp_path, monkeypatch):
+def test_the_stages_run_inside_the_lineage_and_are_recorded(tmp_path, monkeypatch):
     plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
     parent = _write_parent_config(tmp_path)
     root = tmp_path / "rebasecall_outputs"
-    seen: list[dict[str, object]] = []
-
-    def runner(config_path, *, lineage_provenance):
-        seen.append(
-            {
-                "config": _config_values(Path(config_path)),
-                "provenance": dict(lineage_provenance),
-            }
-        )
-        return (
-            None,
-            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
-            None,
-        )
+    raw_seen: list[dict[str, object]] = []
+    preprocess_seen: list[dict[str, object]] = []
 
     result = run_lineage_raw_stage(
         plan,
@@ -104,19 +108,60 @@ def test_the_raw_stage_runs_inside_the_lineage_and_is_recorded(tmp_path, monkeyp
         root,
         accepted_plan_id=plan.plan_id,
         parent_config_path=parent,
-        raw_stage_runner=runner,
+        raw_stage_runner=_stage_runner(tmp_path, "raw_outputs", "descendant-a", record=raw_seen),
+        preprocess_stage_runner=_stage_runner(
+            tmp_path,
+            "preprocess_adata_outputs",
+            "descendant-p",
+            record=preprocess_seen,
+        ),
     )
 
     assert result.raw_generation_id == "descendant-a"
-    assert result.lineage.stage_generations == {"raw": "descendant-a"}
-    assert len(seen) == 1
-    assert seen[0]["config"]["input_data_path"] == str(basecall.directory / BASECALL_BAM_FILENAME)
+    assert result.lineage.stage_generations == {
+        "raw": "descendant-a",
+        "preprocess": "descendant-p",
+    }
+    assert len(raw_seen) == 1 and len(preprocess_seen) == 1
+    assert raw_seen[0]["config"]["input_data_path"] == str(
+        basecall.directory / BASECALL_BAM_FILENAME
+    )
+    provenance = dict(raw_seen[0]["lineage_provenance"])
     # Per D2 the descendant derives its kind from the basecall it was built from.
-    assert seen[0]["provenance"]["generation_kind"] == basecall.generation_kind
-    assert seen[0]["provenance"]["basecall_id"] == basecall.basecall_id
-    assert seen[0]["provenance"]["lineage_id"] == result.lineage.lineage_id
+    assert provenance["generation_kind"] == basecall.generation_kind
+    assert provenance["basecall_id"] == basecall.basecall_id
+    assert provenance["lineage_id"] == result.lineage.lineage_id
+    # Preprocess must read the descendant raw generation, not whatever the
+    # parent currently selects.
+    assert preprocess_seen[0]["lineage_generations"] == {"raw": "descendant-a"}
     assert (result.lineage.directory / DESCENDANT_CONFIG_FILENAME).is_file()
     assert result.descendant_config_path.is_file()
+
+
+def test_a_raw_only_target_stops_after_raw(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    plan = replace(plan, request=replace(plan.request, downstream_target="raw"))
+    parent = _write_parent_config(tmp_path)
+    preprocess_calls: list[dict[str, object]] = []
+
+    result = run_lineage_raw_stage(
+        plan,
+        frozen,
+        basecall,
+        tmp_path / "rebasecall_outputs",
+        accepted_plan_id=plan.plan_id,
+        parent_config_path=parent,
+        raw_stage_runner=_stage_runner(tmp_path, "raw_outputs", "descendant-a"),
+        preprocess_stage_runner=_stage_runner(
+            tmp_path,
+            "preprocess_adata_outputs",
+            "descendant-p",
+            record=preprocess_calls,
+        ),
+    )
+
+    assert result.lineage.stage_generations == {"raw": "descendant-a"}
+    assert preprocess_calls == []
 
 
 def test_the_result_payload_follows_the_workflow_contract(tmp_path, monkeypatch):
@@ -130,18 +175,18 @@ def test_the_result_payload_follows_the_workflow_contract(tmp_path, monkeypatch)
         tmp_path / "rebasecall_outputs",
         accepted_plan_id=plan.plan_id,
         parent_config_path=parent,
-        raw_stage_runner=lambda config_path, *, lineage_provenance: (
-            None,
-            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
-            None,
-        ),
+        raw_stage_runner=_stage_runner(tmp_path, "raw_outputs", "descendant-a"),
+        preprocess_stage_runner=_stage_runner(tmp_path, "preprocess_adata_outputs", "descendant-p"),
     )
 
     payload = result.to_dict()
 
     assert payload["lineage_id"] == result.lineage.lineage_id
     assert payload["basecall_id"] == basecall.basecall_id
-    assert payload["stage_generations"] == {"raw": "descendant-a"}
+    assert payload["stage_generations"] == {
+        "raw": "descendant-a",
+        "preprocess": "descendant-p",
+    }
     assert payload["raw_generation_id"] == "descendant-a"
     assert Path(payload["run_root"]) == Path(plan.run_root)
 
@@ -151,7 +196,7 @@ def test_a_killed_raw_stage_publishes_no_lineage(tmp_path, monkeypatch):
     parent = _write_parent_config(tmp_path)
     root = tmp_path / "rebasecall_outputs"
 
-    def killed(config_path, *, lineage_provenance):
+    def killed(config_path, **_kwargs):
         raise RuntimeError("raw stage was killed")
 
     with pytest.raises(RuntimeError, match="raw stage was killed"):
@@ -183,7 +228,7 @@ def test_a_raw_stage_that_reports_no_generation_is_an_error(tmp_path, monkeypatc
             root,
             accepted_plan_id=plan.plan_id,
             parent_config_path=parent,
-            raw_stage_runner=lambda config_path, *, lineage_provenance: None,
+            raw_stage_runner=lambda config_path, **_kwargs: None,
         )
 
     assert error.value.code == "lineage_raw_stage_unrecognized"
@@ -201,11 +246,8 @@ def test_a_relocated_lineage_still_validates(tmp_path, monkeypatch):
         root,
         accepted_plan_id=plan.plan_id,
         parent_config_path=parent,
-        raw_stage_runner=lambda config_path, *, lineage_provenance: (
-            None,
-            tmp_path / "raw_outputs" / "generations" / "descendant-a" / "spine.h5ad",
-            None,
-        ),
+        raw_stage_runner=_stage_runner(tmp_path, "raw_outputs", "descendant-a"),
+        preprocess_stage_runner=_stage_runner(tmp_path, "preprocess_adata_outputs", "descendant-p"),
     )
 
     relocated = tmp_path / "moved_outputs"
@@ -214,4 +256,4 @@ def test_a_relocated_lineage_still_validates(tmp_path, monkeypatch):
 
     # Lineage identity is path-neutral, so moving the container preserves it.
     assert [item.lineage_id for item in moved] == [result.lineage.lineage_id]
-    assert moved[0].stage_generations == {"raw": "descendant-a"}
+    assert moved[0].stage_generations == {"raw": "descendant-a", "preprocess": "descendant-p"}


### PR DESCRIPTION
`SRB-05` publishes a lineage whose descendant raw generation was really built, but the lineage stopped there. Preprocess had no way to read a descendant: it resolves its source through `current.json`, which by design still answers with the parent.

Thread the `D1` selector down to where paths are computed. `get_adata_paths(lineage_generations=...)` pins which generation each stage resolves, `preprocess_adata` accepts that pin plus lineage provenance, and `run_lineage_raw_stage` runs preprocess after raw whenever the accepted request's `downstream.target` is deeper than `raw`, recording its generation in the lineage. Every stage runs inside the transaction, so the exit gate still holds across the deeper run.

Doing this exposed a hazard in the shared helper worth stating plainly. `staged_generation` ran its `after_current` hook unconditionally -- but preprocess and latent use that hook to publish the **canonical stage-root spine**, the file ordinary readers resolve. A descendant published with `select_current=False` would have overwritten it, and the parent's readers would have silently started reading descendant data. The hook is now two:

- `after_publish` runs after the move, always: work describing the generation, such as raw's validation of its published tree.
- `after_current` runs only when the selector actually advances: work that follows *selection*, such as canonical spine publication.

That distinction is the difference between publishing and selecting, which this whole lineage model depends on, so it is covered directly rather than implied.

`validate_lineage_provenance` moves into `informatics/generation.py` as shared vocabulary; raw and preprocess both use it and wrap it in their own error types. Preprocess records the same optional `lineage` block, without a schema bump -- unlike raw, its validator compares schema versions with `!=`, so bumping would invalidate every preprocess generation already on disk.

One correction found by the suite: threading these keywords first changed the *ordinary* call signatures and broke four existing test doubles. Lineage kwargs are now passed only when a lineage is in play, so an ordinary run is unchanged for every existing caller.

Scope: this is the downstream-execution mechanism, proven through preprocess. Two pieces of `SRB-06` remain and are recorded in the plan -- spatial/hmm/latent need the same threading (they publish canonical spines directly, so the same hazard applies), and the QC transition report, which is the lane's exit gate.

Full unit suite 2,057 passed, 8 skipped, 181 deselected, 7 xfailed; 55 integration, 106 smoke; Ruff check/format and Sphinx `-W` clean.