### PR TITLE
feat: run spatial, hmm, and latent inside a lineage

### DIFF
--- a/src/smftools/cli/hmm_adata.py
+++ b/src/smftools/cli/hmm_adata.py
@@ -4,7 +4,7 @@ import copy
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -779,7 +779,12 @@ def _feature_ranges_for_merged_layer(core_layer: str, feature_sets: dict) -> dic
 
 
 @stage_logging_lifecycle
-def hmm_adata(config_path: str):
+def hmm_adata(
+    config_path: str,
+    *,
+    lineage_generations: Mapping[str, str] | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
+):
     """
     CLI-facing wrapper for HMM analysis.
 
@@ -811,14 +816,21 @@ def hmm_adata(config_path: str):
     if getattr(cfg, "output_directory", None) is not None:
         setup_stage_logging(cfg, Path(cfg.output_directory) / HMM_DIR)
 
-    paths = get_adata_paths(cfg)
+    paths = (
+        get_adata_paths(cfg, lineage_generations=lineage_generations)
+        if lineage_generations
+        else get_adata_paths(cfg)
+    )
     execution_mode = str(getattr(cfg, "hmm_execution_mode", "auto")).lower()
     if execution_mode not in {"auto", "legacy", "partitioned"}:
         raise ValueError("hmm_execution_mode must be auto, legacy, or partitioned")
 
     # 2) choose starting AnnData
+    # A lineage builds a descendant beside whatever is current, so the parent
+    # looking complete says nothing about whether this run has work to do.
     force_redo = (
-        cfg.force_redo_hmm_fit
+        lineage_provenance is not None
+        or cfg.force_redo_hmm_fit
         or cfg.force_redo_hmm_apply
         or getattr(cfg, "force_redo_hmm_plots", False)
     )
@@ -905,7 +917,11 @@ def hmm_adata(config_path: str):
                 # failure leaves the previously current generation selected and
                 # untouched. Artifact paths returned here therefore point into
                 # staging and are remapped after publication.
-                with staged_generation(hmm_root, run_root=run_root) as staged:
+                with staged_generation(
+                    hmm_root,
+                    run_root=run_root,
+                    select_current=lineage_provenance is None,
+                ) as staged:
                     outputs = execute_partitioned_hmm(
                         partitioned_source,
                         cfg,
@@ -931,6 +947,9 @@ def hmm_adata(config_path: str):
                             "stage": "hmm",
                             "config_hash": stage_config_hash(cfg, "hmm"),
                             "rebound_spine_pointers": rebound,
+                            "lineage": (
+                                dict(lineage_provenance) if lineage_provenance is not None else None
+                            ),
                         }
                     )
             outputs = remap_staged_paths(outputs, staged)
@@ -938,14 +957,21 @@ def hmm_adata(config_path: str):
             # paths.hmm_spine keep resolving. It sits two levels below the run
             # root, so its run-root-relative uns pointers resolve unchanged.
             canonical_spine = hmm_root / HMM_SPINE_FILENAME
-            publish_canonical_spine(outputs["spine"], canonical_spine)
+            # A non-selected descendant must not overwrite the canonical stage-root
+            # spine: that file is what ordinary readers resolve, and it belongs
+            # to whatever generation is current.
+            if lineage_provenance is None:
+                publish_canonical_spine(outputs["spine"], canonical_spine)
             outputs["generation"] = staged.final_dir
             outputs["generation_spine"] = outputs["spine"]
             outputs["generation_manifest"] = staged.final_dir / GENERATION_MANIFEST
             outputs["current"] = hmm_root / "current.json"
             # `spine` stays the stable stage-root path readers resolve;
-            # `generation_spine` records the copy inside this generation.
-            outputs["spine"] = canonical_spine
+            # `generation_spine` records the copy inside this generation. A
+            # descendant has no claim on the stage-root path, so it reports its
+            # own generation spine for both.
+            if lineage_provenance is None:
+                outputs["spine"] = canonical_spine
             publish_stage_outputs(
                 lifecycle,
                 outputs,

--- a/src/smftools/cli/latent_adata.py
+++ b/src/smftools/cli/latent_adata.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple
 
 import anndata as ad
 
@@ -205,6 +205,9 @@ def _build_reference_position_mask(
 
 def latent_adata(
     config_path: str,
+    *,
+    lineage_generations: Mapping[str, str] | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
 ) -> Tuple[Optional[ad.AnnData], Optional[Path]]:
     """
     CLI-facing wrapper for representation learning.
@@ -233,7 +236,11 @@ def latent_adata(
     if getattr(cfg, "output_directory", None) is not None:
         setup_stage_logging(cfg, Path(cfg.output_directory) / LATENT_DIR)
 
-    paths = get_adata_paths(cfg)
+    paths = (
+        get_adata_paths(cfg, lineage_generations=lineage_generations)
+        if lineage_generations
+        else get_adata_paths(cfg)
+    )
 
     latent_path = paths.latent
     partitioned_latent_path = paths.latent_spine
@@ -241,7 +248,11 @@ def latent_adata(
     if execution_mode not in {"auto", "legacy", "partitioned"}:
         raise ValueError("latent_execution_mode must be auto, legacy, or partitioned")
 
-    force_redo = bool(getattr(cfg, "force_redo_latent_analyses", False))
+    # A lineage builds a descendant beside whatever is current, so the parent
+    # looking complete says nothing about whether this run has work to do.
+    force_redo = lineage_provenance is not None or bool(
+        getattr(cfg, "force_redo_latent_analyses", False)
+    )
     if not force_redo and execution_mode == "legacy":
         if latent_path.exists():
             logger.info(f"Latent AnnData found: {latent_path}\nSkipping smftools latent")
@@ -307,6 +318,7 @@ def latent_adata(
                 cfg,
                 Path(cfg.output_directory) / LATENT_DIR,
                 reuse_generation=reuse_generation,
+                lineage_provenance=lineage_provenance,
             )
             path_outputs = {key: value for key, value in outputs.items() if isinstance(value, Path)}
             publish_stage_outputs(

--- a/src/smftools/cli/spatial_adata.py
+++ b/src/smftools/cli/spatial_adata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 import anndata as ad
 
@@ -19,6 +19,9 @@ logger = get_logger(__name__)
 @stage_logging_lifecycle
 def spatial_adata(
     config_path: str,
+    *,
+    lineage_generations: Mapping[str, str] | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
 ) -> Tuple[Optional[ad.AnnData], Optional[Path]]:
     """
     CLI-facing wrapper for spatial analyses.
@@ -59,7 +62,11 @@ def spatial_adata(
     if getattr(cfg, "output_directory", None) is not None:
         setup_stage_logging(cfg, Path(cfg.output_directory) / SPATIAL_DIR)
 
-    paths = get_adata_paths(cfg)
+    paths = (
+        get_adata_paths(cfg, lineage_generations=lineage_generations)
+        if lineage_generations
+        else get_adata_paths(cfg)
+    )
 
     spatial_path = paths.spatial
     partitioned_spatial_path = paths.spatial_spine
@@ -68,8 +75,10 @@ def spatial_adata(
     if execution_mode not in {"auto", "legacy", "partitioned"}:
         raise ValueError("spatial_execution_mode must be auto, legacy, or partitioned")
 
+    # A lineage builds a descendant beside whatever is current, so the parent
+    # looking complete says nothing about whether this run has work to do.
     # Stage-skipping logic for spatial
-    if not getattr(cfg, "force_redo_spatial_analyses", False):
+    if lineage_provenance is None and not getattr(cfg, "force_redo_spatial_analyses", False):
         if (
             execution_mode != "legacy"
             and partitioned_spatial_path is not None
@@ -135,7 +144,11 @@ def spatial_adata(
             with perf_substep("partitioned_spatial"):
                 # Built inside staging, so a failure leaves the previously
                 # current generation selected and untouched.
-                with staged_generation(spatial_root, run_root=run_root) as staged:
+                with staged_generation(
+                    spatial_root,
+                    run_root=run_root,
+                    select_current=lineage_provenance is None,
+                ) as staged:
                     outputs = execute_partitioned_spatial(
                         partitioned_source_path,
                         cfg,
@@ -161,18 +174,28 @@ def spatial_adata(
                             "stage": "spatial",
                             "config_hash": stage_config_hash(cfg, "spatial"),
                             "rebound_spine_pointers": rebound,
+                            "lineage": (
+                                dict(lineage_provenance) if lineage_provenance is not None else None
+                            ),
                         }
                     )
             outputs = remap_staged_paths(outputs, staged)
             canonical_spine = spatial_root / SPATIAL_SPINE_FILENAME
-            publish_canonical_spine(outputs["spine"], canonical_spine)
+            # A non-selected descendant must not overwrite the canonical stage-root
+            # spine: that file is what ordinary readers resolve, and it belongs
+            # to whatever generation is current.
+            if lineage_provenance is None:
+                publish_canonical_spine(outputs["spine"], canonical_spine)
             outputs["generation"] = staged.final_dir
             outputs["generation_spine"] = outputs["spine"]
             outputs["generation_manifest"] = staged.final_dir / GENERATION_MANIFEST
             outputs["current"] = spatial_root / "current.json"
             # `spine` stays the stable stage-root path readers resolve;
-            # `generation_spine` records the copy inside this generation.
-            outputs["spine"] = canonical_spine
+            # `generation_spine` records the copy inside this generation. A
+            # descendant has no claim on the stage-root path, so it reports its
+            # own generation spine for both.
+            if lineage_provenance is None:
+                outputs["spine"] = canonical_spine
             publish_stage_outputs(
                 lifecycle,
                 outputs,

--- a/src/smftools/pipeline/rebasecall_run.py
+++ b/src/smftools/pipeline/rebasecall_run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
@@ -22,10 +23,27 @@ from .rebasecall_transition import build_qc_transition, write_qc_transition
 
 DESCENDANT_CONFIG_FILENAME = "descendant_config.csv"
 
-# Stages a lineage can currently run. Deeper targets are refused rather than
-# silently stopping at preprocess, because a lineage that quietly delivered less
-# than its accepted request asked for would be worse than one that declined.
-_SUPPORTED_TARGETS = frozenset({"raw", "preprocess"})
+_STAGE_MODULES = {
+    "raw": "raw_adata",
+    "preprocess": "preprocess_adata",
+    "spatial": "spatial_adata",
+    "hmm": "hmm_adata",
+    "latent": "latent_adata",
+}
+
+# Stage order a lineage executes, and the stage each target stops after. A
+# lineage that quietly delivered less than its accepted request asked for would
+# be worse than one that declined, so an unknown target is refused rather than
+# truncated.
+_LINEAGE_STAGE_ORDER = ("raw", "preprocess", "spatial", "hmm", "latent")
+_TARGET_STAGES = {
+    "raw": ("raw",),
+    "preprocess": ("raw", "preprocess"),
+    "spatial": ("raw", "preprocess", "spatial"),
+    "hmm": ("raw", "preprocess", "spatial", "hmm"),
+    "latent": ("raw", "preprocess", "spatial", "hmm", "latent"),
+    "full": _LINEAGE_STAGE_ORDER,
+}
 
 # Fields the descendant overrides. Everything else is inherited verbatim: a
 # lineage re-runs the *same* experiment against new calls, so silently changing
@@ -123,6 +141,9 @@ def run_lineage_raw_stage(
     parent_config_path: str | Path,
     raw_stage_runner: Callable[..., Any] | None = None,
     preprocess_stage_runner: Callable[..., Any] | None = None,
+    spatial_stage_runner: Callable[..., Any] | None = None,
+    hmm_stage_runner: Callable[..., Any] | None = None,
+    latent_stage_runner: Callable[..., Any] | None = None,
     identity_map: str | None = None,
 ) -> LineageRawStageResult:
     """Publish one lineage whose descendant generations were actually built.
@@ -131,22 +152,24 @@ def run_lineage_raw_stage(
     leaves the parent run and every prior complete lineage untouched: no
     descendant generation is ever selected, and the lineage never appears.
 
-    How far this runs is the accepted request's ``downstream.target``. A target
-    of ``raw`` stops after raw; anything deeper also preprocesses, reading the
-    descendant raw generation rather than whatever the parent currently selects.
+    How far this runs is the accepted request's ``downstream.target``: ``raw``
+    stops after raw, ``full`` runs the whole chain. Every stage reads the
+    generations this lineage already published rather than whatever the parent
+    currently selects.
     """
-    if plan.request.downstream_target not in _SUPPORTED_TARGETS:
+    target = plan.request.downstream_target
+    if target not in _TARGET_STAGES:
         raise RebasecallLineageError(
             "lineage_target_unsupported",
-            f"lineage execution supports {sorted(_SUPPORTED_TARGETS)}; "
-            f"{plan.request.downstream_target!r} needs spatial/hmm/latent threading (SRB-06c)",
+            f"lineage execution supports {sorted(_TARGET_STAGES)}; {target!r} is not a target",
         )
-    if raw_stage_runner is None:
-        from ..cli.raw_adata import raw_adata as raw_stage_runner  # noqa: PLC0415
-    if preprocess_stage_runner is None:
-        from ..cli.preprocess_adata import (  # noqa: PLC0415
-            preprocess_adata as preprocess_stage_runner,
-        )
+    runners = _stage_runners(
+        raw=raw_stage_runner,
+        preprocess=preprocess_stage_runner,
+        spatial=spatial_stage_runner,
+        hmm=hmm_stage_runner,
+        latent=latent_stage_runner,
+    )
 
     rebasecall_root = Path(rebasecall_root)
     identity = build_lineage_identity(plan, selection, basecall)
@@ -170,18 +193,19 @@ def run_lineage_raw_stage(
             basecall,
             identity_map=identity_map,
         )
-        result = raw_stage_runner(str(descendant_config), lineage_provenance=provenance)
-        generation_id = _descendant_generation_id(result)
-        staged.record_stage_generation("raw", generation_id)
-        preprocess_generation_id = None
-        if plan.request.downstream_target != "raw":
-            preprocess_result = preprocess_stage_runner(
-                str(descendant_config),
-                lineage_generations={"raw": generation_id},
-                lineage_provenance=provenance,
-            )
-            preprocess_generation_id = _descendant_generation_id(preprocess_result)
-            staged.record_stage_generation("preprocess", preprocess_generation_id)
+        # Each stage reads the generations this lineage already published, not
+        # whatever the parent currently selects, so the chain stays internally
+        # consistent even while the parent keeps answering for ordinary readers.
+        pinned: dict[str, str] = {}
+        for stage in _TARGET_STAGES[target]:
+            stage_kwargs: dict[str, Any] = {"lineage_provenance": provenance}
+            if pinned:
+                stage_kwargs["lineage_generations"] = dict(pinned)
+            stage_result = runners[stage](str(descendant_config), **stage_kwargs)
+            pinned[stage] = _descendant_generation_id(stage_result)
+            staged.record_stage_generation(stage, pinned[stage])
+        generation_id = pinned["raw"]
+        preprocess_generation_id = pinned.get("preprocess")
         final_dir = staged.final_dir
 
     lineage = read_published_rebasecall_lineage(final_dir, expected_lineage_id=staged.lineage_id)
@@ -206,6 +230,18 @@ def run_lineage_raw_stage(
         run_root=run_root,
         qc_transition=summary.to_dict(),
     )
+
+
+def _stage_runners(**overrides: Callable[..., Any] | None) -> dict[str, Callable[..., Any]]:
+    """Resolve each stage's runner, importing the real CLI stage only if needed."""
+    resolved: dict[str, Callable[..., Any]] = {}
+    for stage, override in overrides.items():
+        if override is not None:
+            resolved[stage] = override
+            continue
+        module = import_module(f"..cli.{_STAGE_MODULES[stage]}", __package__)
+        resolved[stage] = getattr(module, _STAGE_MODULES[stage])
+    return resolved
 
 
 def _descendant_generation_id(result: Any) -> str:

--- a/src/smftools/tools/partitioned_latent.py
+++ b/src/smftools/tools/partitioned_latent.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import warnings
 from pathlib import Path
+from typing import Any, Mapping
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -1886,8 +1887,14 @@ def execute_partitioned_latent(
     output_dir,
     *,
     reuse_generation: str | Path | None = None,
+    lineage_provenance: Mapping[str, Any] | None = None,
 ) -> dict[str, Path | str | int]:
-    """Build, validate, and atomically publish one immutable latent generation."""
+    """Build, validate, and atomically publish one immutable latent generation.
+
+    ``lineage_provenance`` marks the result as a re-basecalled descendant, which
+    publishes beside the parent's generation without advancing ``current.json``.
+    The canonical stage-root spine follows selection, so it is left alone.
+    """
     from ..cli.helpers import stage_config_hash, stage_plot_config_hash
 
     spine_path = Path(spine_path)
@@ -1910,6 +1917,7 @@ def execute_partitioned_latent(
         validate=validate,
         write_json=atomic_write_json,
         after_current=publish_spine,
+        select_current=lineage_provenance is None,
     ) as staged:
         generation_id = staged.generation_id
         staging_dir = staged.staging_dir
@@ -2141,6 +2149,7 @@ def execute_partitioned_latent(
             {
                 "schema_version": LATENT_GENERATION_SCHEMA_VERSION,
                 "generation_id": generation_id,
+                "lineage": (dict(lineage_provenance) if lineage_provenance is not None else None),
                 "compute_config_hash": stage_config_hash(cfg, "latent"),
                 "plot_config_hash": stage_plot_config_hash(cfg, "latent"),
                 "source": source_provenance,

--- a/tests/unit/pipeline/test_rebasecall_run.py
+++ b/tests/unit/pipeline/test_rebasecall_run.py
@@ -327,3 +327,72 @@ def test_the_lineage_publishes_a_reconcilable_transition_report(tmp_path, monkey
     assert len(frame) == len(selected)
     assert summary["selected_molecule_count"] == len(selected)
     assert result.to_dict()["qc_transition"]["passes_qc_count"] == len(selected)
+
+
+def test_a_full_target_runs_every_stage_pinned_to_its_own_lineage(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch, target="full")
+    parent = _write_parent_config(tmp_path)
+    selected = _selected_reads(frozen)
+    seen: dict[str, dict[str, object]] = {}
+
+    def runner_for(stage, directory, generation_id):
+        record: list[dict[str, object]] = []
+
+        def runner(config_path, **kwargs):
+            seen[stage] = kwargs
+            return _stage_runner(
+                tmp_path, directory, generation_id, record=record, read_ids=selected
+            )(config_path, **kwargs)
+
+        return runner
+
+    result = run_lineage_raw_stage(
+        plan,
+        frozen,
+        basecall,
+        tmp_path / "rebasecall_outputs",
+        accepted_plan_id=plan.plan_id,
+        parent_config_path=parent,
+        raw_stage_runner=runner_for("raw", "raw_outputs", "descendant-raw"),
+        preprocess_stage_runner=runner_for(
+            "preprocess", "preprocess_adata_outputs", "descendant-pre"
+        ),
+        spatial_stage_runner=runner_for("spatial", "spatial_adata_outputs", "descendant-spa"),
+        hmm_stage_runner=runner_for("hmm", "hmm_adata_outputs", "descendant-hmm"),
+        latent_stage_runner=runner_for("latent", "latent_adata_outputs", "descendant-lat"),
+    )
+
+    assert result.lineage.stage_generations == {
+        "raw": "descendant-raw",
+        "preprocess": "descendant-pre",
+        "spatial": "descendant-spa",
+        "hmm": "descendant-hmm",
+        "latent": "descendant-lat",
+    }
+    # Raw has nothing upstream to pin; every later stage reads the generations
+    # this lineage already published, never the parent's current ones.
+    assert "lineage_generations" not in seen["raw"]
+    assert seen["preprocess"]["lineage_generations"] == {"raw": "descendant-raw"}
+    assert seen["latent"]["lineage_generations"] == {
+        "raw": "descendant-raw",
+        "preprocess": "descendant-pre",
+        "spatial": "descendant-spa",
+        "hmm": "descendant-hmm",
+    }
+
+
+def test_an_unknown_target_is_refused(tmp_path, monkeypatch):
+    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
+    unknown = replace(plan, request=replace(plan.request, downstream_target="chimeric"))
+
+    with pytest.raises(RebasecallLineageError) as error:
+        run_lineage_raw_stage(
+            unknown,
+            frozen,
+            basecall,
+            tmp_path / "rebasecall_outputs",
+            accepted_plan_id=unknown.plan_id,
+            parent_config_path=tmp_path / "missing.csv",
+        )
+
+    assert error.value.code == "lineage_target_unsupported"

--- a/tests/unit/pipeline/test_rebasecall_transition.py
+++ b/tests/unit/pipeline/test_rebasecall_transition.py
@@ -243,22 +243,3 @@ def test_a_lineage_without_a_report_says_so(tmp_path, monkeypatch):
         read_qc_transition(lineage)
 
     assert error.value.code == "transition_report_missing"
-
-
-def test_deeper_targets_are_refused_rather_than_stopping_short(tmp_path, monkeypatch):
-    from smftools.pipeline.rebasecall_run import run_lineage_raw_stage
-
-    plan, frozen, basecall = _lineage_case(tmp_path, monkeypatch)
-    deep = replace(plan, request=replace(plan.request, downstream_target="hmm"))
-
-    with pytest.raises(RebasecallLineageError) as error:
-        run_lineage_raw_stage(
-            deep,
-            frozen,
-            basecall,
-            tmp_path / "rebasecall_outputs",
-            accepted_plan_id=deep.plan_id,
-            parent_config_path=tmp_path / "missing.csv",
-        )
-
-    assert error.value.code == "lineage_target_unsupported"

--- a/tests/unit/test_hmm_partitioned_cli.py
+++ b/tests/unit/test_hmm_partitioned_cli.py
@@ -1070,3 +1070,88 @@ def test_plot_hmm_parameters_across_barcodes_skips_single_barcode_windows(tmp_pa
 
     catalog = pd.read_parquet(layout.catalog)
     assert catalog.empty
+
+
+_LINEAGE_PROVENANCE = {
+    "lineage_id": "a" * 64,
+    "origin_experiment_uid": "uid-a",
+    "parent_raw_generation_id": "parent-a",
+    "parent_preprocess_generation_id": None,
+    "selection_id": "b" * 64,
+    "source_resolution_digest": None,
+    "basecall_id": "c" * 64,
+    "generation_kind": "selected_cohort",
+    "identity_map": None,
+}
+
+
+def test_a_descendant_hmm_generation_does_not_take_the_canonical_spine(tmp_path, monkeypatch):
+    """The stage-root spine belongs to whatever generation is current."""
+    from smftools.cli import helpers
+    from smftools.tools import partitioned_hmm
+
+    spatial_spine = tmp_path / "spatial_adata_outputs" / "spine.h5ad"
+    spatial_spine.parent.mkdir()
+    spatial_spine.touch()
+    hmm_root = tmp_path / "hmm_adata_outputs"
+    paths = SimpleNamespace(
+        hmm=tmp_path / "missing_hmm.h5ad.gz",
+        hmm_spine=hmm_root / "spine.h5ad",
+        spatial_spine=spatial_spine,
+        preprocess_spine=None,
+    )
+    cfg = SimpleNamespace(
+        output_directory=tmp_path,
+        hmm_execution_mode="auto",
+        force_redo_hmm_fit=False,
+        force_redo_hmm_apply=False,
+        force_redo_hmm_plots=False,
+        from_adata_stage=None,
+    )
+    monkeypatch.setattr(helpers, "load_experiment_config", lambda _path: cfg)
+    monkeypatch.setattr(helpers, "get_adata_paths", lambda _cfg, **_kwargs: paths)
+
+    def execute(_source, _cfg, output_dir):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        # The real executor writes its spine inside the staging directory, which
+        # is what lets publication remap it into the generation.
+        staged_spine = output_dir / "spine.h5ad"
+        ad.AnnData().write_h5ad(staged_spine)
+        task_catalog = output_dir / "task_catalog.parquet"
+        pd.DataFrame({"task_id": ["task-1"]}).to_parquet(task_catalog, index=False)
+        for name in ("store", "read_index", "models"):
+            (output_dir / name).mkdir()
+        (output_dir / "store" / "task-1").touch()
+        (output_dir / "models" / "model-1.json").write_text("{}\n", encoding="utf-8")
+        plot_catalog = output_dir / "plots" / "catalog.parquet"
+        plot_catalog.parent.mkdir()
+        pd.DataFrame().to_parquet(plot_catalog, index=False)
+        (output_dir / "sidecar_manifest.json").write_text("{}\n", encoding="utf-8")
+        return {
+            "spine": staged_spine,
+            "task_catalog": task_catalog,
+            "read_index": output_dir / "read_index",
+            "store": output_dir / "store",
+            "models": output_dir / "models",
+            "plot_catalog": plot_catalog,
+            "manifest": output_dir / "sidecar_manifest.json",
+        }
+
+    monkeypatch.setattr(partitioned_hmm, "execute_partitioned_hmm", execute)
+
+    hmm_adata("experiment.csv")
+    parent_pointer = json.loads((hmm_root / "current.json").read_text(encoding="utf-8"))
+
+    _, descendant_spine = hmm_adata(
+        "experiment.csv",
+        lineage_provenance=dict(_LINEAGE_PROVENANCE),
+    )
+
+    # The descendant published its own generation without taking the selector.
+    assert descendant_spine != paths.hmm_spine
+    assert descendant_spine.parent.parent.name == "generations"
+    manifest = json.loads(
+        (descendant_spine.parent / "generation_manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["lineage"] == _LINEAGE_PROVENANCE
+    assert json.loads((hmm_root / "current.json").read_text(encoding="utf-8")) == parent_pointer

--- a/tests/unit/test_spatial_partitioned_cli.py
+++ b/tests/unit/test_spatial_partitioned_cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -240,3 +241,54 @@ def test_spatial_cli_records_failed_stage_when_executor_raises(tmp_path, monkeyp
     entry = read_experiment_manifest(tmp_path)["stages"]["spatial"]
     assert entry["state"] == "failed"
     assert "simulated spatial plot failure" in entry["outcome"]
+
+
+_LINEAGE_PROVENANCE = {
+    "lineage_id": "a" * 64,
+    "origin_experiment_uid": "uid-a",
+    "parent_raw_generation_id": "parent-a",
+    "parent_preprocess_generation_id": None,
+    "selection_id": "b" * 64,
+    "source_resolution_digest": None,
+    "basecall_id": "c" * 64,
+    "generation_kind": "selected_cohort",
+    "identity_map": None,
+}
+
+
+def test_a_descendant_spatial_generation_does_not_take_the_canonical_spine(tmp_path, monkeypatch):
+    """The stage-root spine belongs to whatever generation is current."""
+    cfg = _cfg(tmp_path)
+    paths = helpers.get_adata_paths(cfg)
+    paths.preprocess_spine.parent.mkdir(parents=True)
+    paths.preprocess_spine.touch()
+    monkeypatch.setattr(helpers, "load_experiment_config", lambda _path: cfg)
+    monkeypatch.setattr(
+        partitioned_spatial,
+        "execute_partitioned_spatial",
+        lambda source, passed_cfg, output: _spatial_outputs(output),
+    )
+
+    # A parent run first, which legitimately takes both current and canonical.
+    spatial_adata("config.csv")
+    canonical = paths.spatial_spine
+    parent_bytes = canonical.read_bytes()
+    parent_pointer = json.loads((canonical.parent / "current.json").read_text(encoding="utf-8"))
+
+    _, descendant_spine = spatial_adata(
+        "config.csv",
+        lineage_provenance=dict(_LINEAGE_PROVENANCE),
+    )
+
+    pointer = json.loads((canonical.parent / "current.json").read_text(encoding="utf-8"))
+    # The descendant published its own generation...
+    assert descendant_spine != canonical
+    assert descendant_spine.parent.parent.name == "generations"
+    assert descendant_spine.is_file()
+    manifest = json.loads(
+        (descendant_spine.parent / "generation_manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["lineage"] == _LINEAGE_PROVENANCE
+    # ...without touching what ordinary readers resolve.
+    assert pointer == parent_pointer
+    assert canonical.read_bytes() == parent_bytes


### PR DESCRIPTION
`SRB-06b` refused targets deeper than preprocess rather than silently stopping there. Thread the remaining three stages so a `full` target runs end to end, and the guard now only rejects a genuinely unknown target.

Each stage takes `lineage_generations` and `lineage_provenance`, publishes with `select_current=False`, and records the `lineage` block in its manifest. The orchestrator maps each target to its stages and pins every stage to the generations this lineage already published, so the chain stays internally consistent while the parent keeps answering for ordinary readers.

The canonical-spine hazard `SRB-06a` fixed for preprocess lives somewhere else for spatial and hmm: they call `publish_canonical_spine` *after* their `staged_generation` block rather than through its hook, so the hook gating did not cover them. Both now skip it for a descendant, and a descendant reports its own generation spine rather than the stage-root path it has no claim on. Latent publishes through `after_current` and was already covered.

A bug only running it could find: the first threading looked right and the descendant spatial run *silently skipped* -- the completeness check saw the parent's spine and concluded there was nothing to do. A lineage builds beside whatever is current, so the parent looking complete says nothing about whether this run has work. Fixed in all three, mirroring what `raw_adata` already did.

Worth recording how the second one surfaced: having found it in spatial, I fixed hmm and latent by inspection -- the exact move that has bitten this program before -- so hmm now has its own real-CLI descendant test. It immediately caught a test double writing its spine to the canonical stage-root path instead of into staging, which is the shape publication depends on to remap a generation.

Direct coverage that a descendant leaves `current.json` and the canonical spine untouched now exists for spatial and hmm through the real CLI, plus a full-chain orchestrator test asserting each stage receives the accumulated pins.

Full unit suite 2,070 passed, 8 skipped, 181 deselected, 7 xfailed; 55 integration, 106 smoke; Ruff check/format and Sphinx `-W` clean.