### PR TITLE
feat: validate a lineage before it can become a project's answer

### DIFF
--- a/src/smftools/pipeline/__init__.py
+++ b/src/smftools/pipeline/__init__.py
@@ -112,6 +112,13 @@ from .rebasecall_transition import (
     reconcile_qc_transition,
     write_qc_transition,
 )
+from .rebasecall_validate import (
+    REBASECALL_VALIDATION_SCHEMA_VERSION,
+    LineageCheck,
+    LineageValidationReport,
+    promote_rebasecall_lineage,
+    validate_rebasecall_lineage,
+)
 from .semantic_graph import (
     AnalysisScope,
     ArtifactIdentity,
@@ -154,7 +161,9 @@ __all__ = [
     "EXPERIMENT_TARGETS",
     "ExperimentExecutionResult",
     "FrozenRebasecallSelection",
+    "LineageCheck",
     "LineageRawStageResult",
+    "LineageValidationReport",
     "MaterializedRebasecallSignal",
     "NodeInputs",
     "NodeResult",
@@ -182,6 +191,7 @@ __all__ = [
     "REBASECALL_SELECTION_SCHEMA_VERSION",
     "REBASECALL_SIGNAL_SCHEMA_VERSION",
     "REBASECALL_TRANSITION_SCHEMA_VERSION",
+    "REBASECALL_VALIDATION_SCHEMA_VERSION",
     "RebasecallBasecallError",
     "RebasecallLineageError",
     "RebasecallModelPlan",
@@ -236,6 +246,7 @@ __all__ = [
     "project_node_inputs",
     "project_node_specs",
     "project_source_member_record",
+    "promote_rebasecall_lineage",
     "rebasecall_request_from_dict",
     "read_frozen_rebasecall_selection",
     "read_materialized_rebasecall_signal",
@@ -247,6 +258,7 @@ __all__ = [
     "run_lineage_raw_stage",
     "run_project_rebasecall",
     "staged_lineage",
+    "validate_rebasecall_lineage",
     "write_lineage_validation",
     "write_qc_transition",
 ]

--- a/src/smftools/pipeline/rebasecall_validate.py
+++ b/src/smftools/pipeline/rebasecall_validate.py
@@ -1,0 +1,341 @@
+"""Validate a published lineage, and promote only what validates.
+
+Registry status is a *claim*; this module is the *check*. A lineage recorded as
+complete may still be missing a stage generation, carry a transition report that
+does not reconcile, or reference a basecall whose bytes have changed. Promotion
+runs the check first, so a user cannot make an incomplete lineage the answer to
+their project by accident.
+
+Replayability is reported separately from completeness. A lineage can be
+complete and still not replayable -- its filtered signal was never materialized
+and its source POD5s have moved on -- and conflating the two would either block
+ordinary promotion or quietly overstate what can be reproduced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from ..project.registry import LineageSelectionError, set_active_lineage
+from .rebasecall_lineage import (
+    PublishedRebasecallLineage,
+    RebasecallLineageError,
+    read_published_rebasecall_lineage,
+    write_lineage_validation,
+)
+
+REBASECALL_VALIDATION_SCHEMA_VERSION = 1
+
+_STAGE_OUTPUT_DIRS = {
+    "raw": "raw_outputs",
+    "preprocess": "preprocess_adata_outputs",
+    "spatial": "spatial_adata_outputs",
+    "hmm": "hmm_adata_outputs",
+    "latent": "latent_adata_outputs",
+}
+
+
+@dataclass(frozen=True)
+class LineageCheck:
+    """One named validation result."""
+
+    name: str
+    passed: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class LineageValidationReport:
+    """The machine-readable summary written beside a validated lineage."""
+
+    lineage_id: str
+    complete: bool
+    replayable: bool | None
+    replay_required: bool = False
+    checks: tuple[LineageCheck, ...] = field(default_factory=tuple)
+    schema_version: int = REBASECALL_VALIDATION_SCHEMA_VERSION
+
+    @property
+    def failures(self) -> tuple[LineageCheck, ...]:
+        """Checks that count against completeness.
+
+        A lineage that is complete but not replayable has no failures: the
+        replay check is informational unless it was required. Reporting it as a
+        failure anyway would make a passing report contradict itself, and would
+        put ``replayable`` in a refusal message that was never about replay.
+        """
+        return tuple(
+            check
+            for check in self.checks
+            if not check.passed and (check.name != "replayable" or self.replay_required)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "lineage_id": self.lineage_id,
+            "complete": self.complete,
+            "replayable": self.replayable,
+            "replay_required": self.replay_required,
+            "checks": [check.to_dict() for check in self.checks],
+            "failures": [check.name for check in self.failures],
+        }
+
+
+def _check(name: str, passed: bool, detail: str) -> LineageCheck:
+    return LineageCheck(name=name, passed=passed, detail=detail)
+
+
+def _validate_stage_generations(
+    lineage: PublishedRebasecallLineage,
+    run_root: Path,
+) -> list[LineageCheck]:
+    """Every generation the lineage claims must exist and validate on its own."""
+    from ..informatics.generation import GenerationError, resolve_stage_generation
+
+    checks: list[LineageCheck] = []
+    for stage, generation_id in sorted(lineage.stage_generations.items()):
+        directory = _STAGE_OUTPUT_DIRS.get(stage)
+        if directory is None:
+            checks.append(_check(f"stage:{stage}", False, f"unknown lineage stage {stage!r}"))
+            continue
+        try:
+            resolved = resolve_stage_generation(run_root / directory, generation_id)
+        except GenerationError as exc:
+            checks.append(_check(f"stage:{stage}", False, str(exc)))
+            continue
+        if resolved is None:
+            checks.append(
+                _check(f"stage:{stage}", False, f"generation {generation_id!r} did not resolve")
+            )
+            continue
+        checks.append(
+            _check(f"stage:{stage}", True, f"generation {generation_id} resolves and validates")
+        )
+    return checks
+
+
+def _validate_transition(lineage: PublishedRebasecallLineage) -> list[LineageCheck]:
+    from .rebasecall_transition import read_qc_transition, reconcile_qc_transition
+
+    try:
+        frame, summary = read_qc_transition(lineage)
+    except RebasecallLineageError as exc:
+        return [_check("qc_transition", False, str(exc))]
+    report = reconcile_qc_transition(frame, summary)
+    if not report["reconciled"]:
+        return [
+            _check(
+                "qc_transition",
+                False,
+                f"published counts do not reconcile: {sorted(report['disagreements'])}",
+            )
+        ]
+    return [
+        _check(
+            "qc_transition",
+            True,
+            f"{len(frame)} selected molecule(s) reconciled against published counts",
+        )
+    ]
+
+
+def _validate_basecall(
+    lineage: PublishedRebasecallLineage,
+    basecall_root: Path | None,
+) -> list[LineageCheck]:
+    if basecall_root is None:
+        return [
+            _check(
+                "basecall",
+                False,
+                "no basecall root supplied, so the lineage's basecall could not be revalidated",
+            )
+        ]
+    from .rebasecall_basecall import read_published_rebasecall_basecall
+
+    directory = Path(basecall_root) / lineage.basecall_id
+    try:
+        published = read_published_rebasecall_basecall(
+            directory,
+            expected_basecall_id=lineage.basecall_id,
+        )
+    except Exception as exc:
+        return [_check("basecall", False, f"{type(exc).__name__}: {exc}")]
+    return [
+        _check(
+            "basecall",
+            True,
+            f"basecall {published.basecall_id} revalidates ({published.generation_kind})",
+        )
+    ]
+
+
+def _validate_replayable(
+    lineage: PublishedRebasecallLineage,
+    basecall_root: Path | None,
+    signal_root: Path | None,
+) -> tuple[bool, LineageCheck]:
+    """Replayable means the signal this lineage was built from is still provable.
+
+    Filtered signal artifacts are self-contained, so they settle it. Original
+    POD5s are only evidence when a resolution recorded their checksums, which
+    lives with the basecall rather than the lineage.
+    """
+    signal_id = None
+    if basecall_root is not None:
+        manifest_path = Path(basecall_root) / lineage.basecall_id / "basecall_manifest.json"
+        if manifest_path.is_file():
+            import json
+
+            try:
+                signal_id = json.loads(manifest_path.read_text(encoding="utf-8")).get("signal_id")
+            except (OSError, ValueError):
+                signal_id = None
+    if signal_id is None:
+        return False, _check(
+            "replayable",
+            False,
+            "no filtered signal artifact was materialized, so replay depends on source POD5s "
+            "that this lineage cannot vouch for",
+        )
+    if signal_root is None:
+        return False, _check(
+            "replayable",
+            False,
+            f"signal {signal_id} was materialized but no signal root was supplied to check it",
+        )
+    from .rebasecall_signal import read_materialized_rebasecall_signal
+
+    try:
+        read_materialized_rebasecall_signal(
+            Path(signal_root) / str(signal_id),
+            expected_signal_id=str(signal_id),
+        )
+    except Exception as exc:
+        return False, _check("replayable", False, f"{type(exc).__name__}: {exc}")
+    return True, _check(
+        "replayable",
+        True,
+        f"filtered signal {signal_id} revalidates, so this lineage can be replayed",
+    )
+
+
+def validate_rebasecall_lineage(
+    lineage_dir: str | Path,
+    run_root: str | Path,
+    *,
+    basecall_root: str | Path | None = None,
+    signal_root: str | Path | None = None,
+    require_replayable: bool = False,
+    write_report: bool = True,
+) -> LineageValidationReport:
+    """Check a published lineage end to end and record the result beside it.
+
+    ``require_replayable`` folds replayability into completeness, for the case
+    where a lineage is being kept as the reproducible record of a publication
+    rather than merely as a result.
+    """
+    lineage_dir = Path(lineage_dir)
+    run_root = Path(run_root)
+    try:
+        lineage = read_published_rebasecall_lineage(lineage_dir)
+    except RebasecallLineageError as exc:
+        return LineageValidationReport(
+            lineage_id=lineage_dir.name,
+            complete=False,
+            replayable=None,
+            checks=(_check("manifest", False, str(exc)),),
+        )
+
+    checks: list[LineageCheck] = [_check("manifest", True, "lineage manifest validates")]
+    checks.extend(_validate_stage_generations(lineage, run_root))
+    checks.extend(_validate_transition(lineage))
+    checks.extend(
+        _validate_basecall(
+            lineage,
+            None if basecall_root is None else Path(basecall_root),
+        )
+    )
+    replayable, replay_check = _validate_replayable(
+        lineage,
+        None if basecall_root is None else Path(basecall_root),
+        None if signal_root is None else Path(signal_root),
+    )
+    checks.append(replay_check)
+
+    # Replayability is reported always and required only on request, so an
+    # ordinary lineage is not blocked for lacking materialized signal.
+    complete = all(
+        check.passed for check in checks if check.name != "replayable" or require_replayable
+    )
+    report = LineageValidationReport(
+        lineage_id=lineage.lineage_id,
+        complete=complete,
+        replayable=replayable,
+        replay_required=require_replayable,
+        checks=tuple(checks),
+    )
+    if write_report:
+        write_lineage_validation(lineage, report.to_dict())
+    return report
+
+
+def promote_rebasecall_lineage(
+    project_dir: str | Path,
+    experiment_id: str,
+    lineage_id: str,
+    *,
+    lineage_dir: str | Path | None = None,
+    run_root: str | Path | None = None,
+    basecall_root: str | Path | None = None,
+    signal_root: str | Path | None = None,
+    require_replayable: bool = False,
+    validator: Callable[..., LineageValidationReport] | None = None,
+) -> Mapping[str, Any]:
+    """Validate a lineage, then make it the experiment's answer.
+
+    Validation comes first and its failure is the refusal, so a user cannot
+    activate an incomplete lineage by accident. Rollback needs no separate
+    machinery: promoting a prior complete lineage -- including ``original`` --
+    is the same operation.
+    """
+    from ..project.registry import ORIGINAL_LINEAGE
+
+    lineage_id = str(lineage_id)
+    report: LineageValidationReport | None = None
+    if lineage_id != ORIGINAL_LINEAGE:
+        if lineage_dir is None or run_root is None:
+            raise RebasecallLineageError(
+                "promotion_unverifiable",
+                "promoting a descendant requires its lineage directory and run root so the "
+                "lineage can be validated before it becomes the answer",
+            )
+        validator = validator or validate_rebasecall_lineage
+        report = validator(
+            lineage_dir,
+            run_root,
+            basecall_root=basecall_root,
+            signal_root=signal_root,
+            require_replayable=require_replayable,
+        )
+        if not report.complete:
+            raise RebasecallLineageError(
+                "lineage_incomplete",
+                "refusing to promote an incomplete lineage; failed checks: "
+                f"{[check.name for check in report.failures]}",
+            )
+    try:
+        active = set_active_lineage(project_dir, experiment_id, lineage_id)
+    except LineageSelectionError as exc:
+        raise RebasecallLineageError("promotion_refused", str(exc)) from exc
+    return {
+        "experiment_id": str(experiment_id),
+        "active_lineage": active,
+        "validation": None if report is None else report.to_dict(),
+    }

--- a/tests/unit/pipeline/test_rebasecall_validate.py
+++ b/tests/unit/pipeline/test_rebasecall_validate.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from tests.unit.pipeline.test_rebasecall_basecall import _case, _execute, _FakeDorado
+from tests.unit.pipeline.test_rebasecall_lineage import _publish_lineage
+
+from smftools.pipeline.rebasecall_lineage import (
+    LINEAGE_MANIFEST_FILENAME,
+    LINEAGE_VALIDATION_FILENAME,
+    RebasecallLineageError,
+)
+from smftools.pipeline.rebasecall_transition import build_qc_transition, write_qc_transition
+from smftools.pipeline.rebasecall_validate import (
+    promote_rebasecall_lineage,
+    validate_rebasecall_lineage,
+)
+from smftools.project import registry as reg
+
+pytestmark = pytest.mark.unit
+
+
+def _stage_generation(run_root: Path, stage_dir: str, generation_id: str) -> Path:
+    """Publish a minimal generation the validator can resolve."""
+    from smftools.informatics.generation import staged_generation
+
+    with staged_generation(run_root / stage_dir, generation_id=generation_id) as staged:
+        (staged.staging_dir / "spine.h5ad").touch()
+        staged.record_manifest({"status": "complete", "stage": stage_dir})
+    return run_root / stage_dir / "generations" / generation_id
+
+
+def _validated_case(tmp_path, monkeypatch, *, with_transition=True):
+    plan, frozen, basecall = None, None, None
+    _, _, plan, frozen = _case(tmp_path, monkeypatch)
+    basecall = _execute(plan, frozen, tmp_path / "basecalls", _FakeDorado())
+    run_root = tmp_path / "run"
+    _stage_generation(run_root, "raw_outputs", "desc-a-0")
+    lineage = _publish_lineage(plan, frozen, basecall, tmp_path / "rebasecall_outputs")
+    if with_transition:
+        selected = sorted(pd.read_parquet(frozen.rows_path)["pod5_read_id"].astype(str))
+        raw_dir = run_root / "raw_outputs" / "generations" / "desc-a-0"
+        pd.DataFrame(
+            {"read_id": selected, "molecule_uid": [f"m-{value}" for value in selected]}
+        ).to_parquet(raw_dir / "obs.parquet", index=False)
+        frame, summary = build_qc_transition(frozen, basecall, raw_dir)
+        write_qc_transition(lineage, frame, summary)
+    return plan, frozen, basecall, lineage, run_root
+
+
+def test_a_complete_lineage_validates_and_records_its_report(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+
+    report = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+
+    assert report.complete is True
+    assert report.failures == ()
+    assert {check.name for check in report.checks} >= {
+        "manifest",
+        "stage:raw",
+        "qc_transition",
+        "basecall",
+        "replayable",
+    }
+    recorded = json.loads(
+        (lineage.directory / LINEAGE_VALIDATION_FILENAME).read_text(encoding="utf-8")
+    )
+    assert recorded["complete"] is True
+    assert recorded["lineage_id"] == lineage.lineage_id
+
+
+def test_replayability_is_reported_separately_from_completeness(tmp_path, monkeypatch):
+    """A lineage can be complete and still not replayable."""
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+
+    without = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+    required = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+        require_replayable=True,
+        write_report=False,
+    )
+
+    # No filtered signal was materialized for this request.
+    assert without.replayable is False
+    assert without.complete is True
+    # Asking for replayability folds it into completeness rather than changing
+    # what "complete" means for everyone else.
+    assert required.complete is False
+    assert [check.name for check in required.failures] == ["replayable"]
+
+
+def test_a_missing_stage_generation_fails_validation(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    import shutil
+
+    shutil.rmtree(run_root / "raw_outputs" / "generations" / "desc-a-0")
+
+    report = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+
+    assert report.complete is False
+    assert "stage:raw" in {check.name for check in report.failures}
+
+
+def test_a_transition_that_does_not_reconcile_fails_validation(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    summary_path = lineage.directory / "qc_transition_summary.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    payload["selected_molecule_count"] += 7
+    summary_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+
+    assert report.complete is False
+    assert "qc_transition" in {check.name for check in report.failures}
+
+
+def test_a_missing_transition_report_fails_validation(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch, with_transition=False)
+
+    report = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+
+    assert report.complete is False
+    assert "qc_transition" in {check.name for check in report.failures}
+
+
+def test_a_tampered_basecall_fails_validation(tmp_path, monkeypatch):
+    _, _, basecall, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    (basecall.directory / "calls.bam").write_text("tampered", encoding="utf-8")
+
+    report = validate_rebasecall_lineage(
+        lineage.directory,
+        run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+
+    assert report.complete is False
+    assert "basecall" in {check.name for check in report.failures}
+
+
+def test_an_unreadable_lineage_reports_rather_than_raises(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    (lineage.directory / LINEAGE_MANIFEST_FILENAME).write_text("{not json", encoding="utf-8")
+
+    report = validate_rebasecall_lineage(lineage.directory, run_root, write_report=False)
+
+    assert report.complete is False
+    assert [check.name for check in report.failures] == ["manifest"]
+
+
+# --- promotion ---------------------------------------------------------------
+
+
+def _project_with_lineage(tmp_path, lineage_id):
+    project_dir = tmp_path / "project"
+    reg.init_project(project_dir)
+    run_root = tmp_path / "exp"
+    run_root.mkdir(parents=True, exist_ok=True)
+    spine = run_root / "spine.h5ad"
+    spine.touch()
+    registry = reg.load_registry(project_dir)
+    registry["experiments"]["exp-a"] = {
+        "path": str(run_root),
+        "name": "exp-a",
+        "experiment_uid": "uid-a",
+        "status": "active",
+        "spines": {"raw": str(spine)},
+        "catalogs": {},
+    }
+    reg.save_registry(project_dir, registry)
+    descendant = run_root / "descendant_spine.h5ad"
+    descendant.touch()
+    reg.register_experiment_lineage(
+        project_dir,
+        "exp-a",
+        lineage_id,
+        spines={"raw": descendant},
+    )
+    return project_dir
+
+
+def test_an_incomplete_lineage_cannot_be_promoted(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch, with_transition=False)
+    project_dir = _project_with_lineage(tmp_path, lineage.lineage_id)
+
+    with pytest.raises(RebasecallLineageError) as error:
+        promote_rebasecall_lineage(
+            project_dir,
+            "exp-a",
+            lineage.lineage_id,
+            lineage_dir=lineage.directory,
+            run_root=run_root,
+            basecall_root=tmp_path / "basecalls",
+        )
+
+    assert error.value.code == "lineage_incomplete"
+    # The project still answers with the original.
+    assert reg.list_experiments(project_dir)[0]["lineage"] == "original"
+
+
+def test_promotion_requires_enough_context_to_verify(tmp_path, monkeypatch):
+    _, _, _, lineage, _ = _validated_case(tmp_path, monkeypatch)
+    project_dir = _project_with_lineage(tmp_path, lineage.lineage_id)
+
+    with pytest.raises(RebasecallLineageError) as error:
+        promote_rebasecall_lineage(project_dir, "exp-a", lineage.lineage_id)
+
+    assert error.value.code == "promotion_unverifiable"
+    assert reg.list_experiments(project_dir)[0]["lineage"] == "original"
+
+
+def test_a_validated_lineage_is_promoted_and_rollback_is_the_same_operation(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    project_dir = _project_with_lineage(tmp_path, lineage.lineage_id)
+
+    promoted = promote_rebasecall_lineage(
+        project_dir,
+        "exp-a",
+        lineage.lineage_id,
+        lineage_dir=lineage.directory,
+        run_root=run_root,
+        basecall_root=tmp_path / "basecalls",
+    )
+    assert promoted["active_lineage"] == lineage.lineage_id
+    assert promoted["validation"]["complete"] is True
+    assert reg.list_experiments(project_dir)[0]["lineage"] == lineage.lineage_id
+
+    # Rollback needs no separate machinery.
+    rolled_back = promote_rebasecall_lineage(project_dir, "exp-a", "original")
+
+    assert rolled_back["active_lineage"] == "original"
+    assert rolled_back["validation"] is None
+    assert reg.list_experiments(project_dir)[0]["lineage"] == "original"
+    # The descendant is still registered and still queryable by name.
+    assert lineage.lineage_id in reg.list_experiments(project_dir)[0]["available_lineages"]
+
+
+def test_promoting_an_unregistered_lineage_is_refused(tmp_path, monkeypatch):
+    _, _, _, lineage, run_root = _validated_case(tmp_path, monkeypatch)
+    project_dir = _project_with_lineage(tmp_path, "some-other-lineage")
+
+    with pytest.raises(RebasecallLineageError) as error:
+        promote_rebasecall_lineage(
+            project_dir,
+            "exp-a",
+            lineage.lineage_id,
+            lineage_dir=lineage.directory,
+            run_root=run_root,
+            basecall_root=tmp_path / "basecalls",
+        )
+
+    assert error.value.code == "promotion_refused"


### PR DESCRIPTION
The registry could already record a lineage as complete and refuse to activate one that was not. But that status is a *claim* the writer made. A lineage marked complete can still be missing a stage generation, carry a transition report that no longer reconciles, or reference a basecall whose bytes have changed since.

Add `pipeline/rebasecall_validate.py`, which is the check rather than the claim. `validate_rebasecall_lineage` revalidates the manifest, every stage generation the lineage names, the QC transition's reconciliation, and the basecall itself, then writes a machine-readable report into the `validation.json` slot the artifact layout has reserved since `SRB-05a`.

`promote_rebasecall_lineage` runs that check first and treats its failure as the refusal, so the exit gate is enforced rather than documented: a user cannot activate an incomplete lineage by accident. Promoting a descendant without enough context to verify it is refused too, so the check cannot be sidestepped by omitting arguments.

Rollback needs no separate machinery. Promoting a prior complete lineage -- including `original` -- is the same operation, and the descendant stays registered and queryable by name afterward.

Replayability is reported separately from completeness. A lineage can be complete and still not replayable: its filtered signal was never materialized and its source POD5s cannot be vouched for. Conflating the two would either block ordinary promotion or quietly overstate what can be reproduced, so `require_replayable` folds it in only for the case where the lineage is being kept as a publication's reproducible record.

One defect my own test caught: `failures` initially included the informational replay check, so a *complete* report could carry non-empty failures -- a summary contradicting itself, and a refusal message naming `replayable` when replay was never the issue. It now means "checks that count against completeness", with `replay_required` recorded in the report.

Scope: this is the enforcement half of `SRB-08`. User documentation distinguishing full-signal from old-QC-selected reanalysis, the publication checklist, and release notes follow in `SRB-08b`.

11 focused tests; full unit suite 2,097 passed, 8 skipped, 181 deselected, 7 xfailed; 55 integration, 106 smoke; Ruff check/format and Sphinx `-W` clean.