### PR TITLE
fix: measure position validity over the reads analyses actually use

### DIFF
--- a/src/smftools/cli/latent_adata.py
+++ b/src/smftools/cli/latent_adata.py
@@ -191,10 +191,26 @@ def _build_reference_position_mask(
 
     ref_masks = []
     for ref in references:
+        # Latent needs positions shared across the reads it will factorize, so
+        # it wants coverage measured over the analysed population. Generations
+        # published before `EGL-11` carry only the assay-wide column; fall back
+        # to it and say so, rather than failing or silently using a quantity
+        # diluted by reads that QC discarded.
+        analysis_col = f"position_in_{ref}_analysis"
         position_col = f"position_in_{ref}"
-        if position_col not in adata.var.columns:
+        if analysis_col in adata.var.columns:
+            chosen = analysis_col
+        elif position_col in adata.var.columns:
+            logger.warning(
+                "%s is unavailable; falling back to %s, which is measured over every "
+                "read the assay produced rather than the analysed reads",
+                analysis_col,
+                position_col,
+            )
+            chosen = position_col
+        else:
             raise KeyError(f"var_filters not found in adata.var: {position_col}")
-        position_mask = np.asarray(adata.var[position_col].values, dtype=bool)
+        position_mask = np.asarray(adata.var[chosen].values, dtype=bool)
         ref_masks.append(position_mask)
 
     if not ref_masks:

--- a/src/smftools/config/experiment_config.py
+++ b/src/smftools/config/experiment_config.py
@@ -1133,6 +1133,11 @@ class ExperimentConfig:
 
     # Preprocessing - Position QC
     position_max_nan_threshold: float = 0.1
+    # Applied to the analysed (QC- and dedup-passing) reads rather than to
+    # every read the assay produced. `None` inherits
+    # `position_max_nan_threshold`; the two are separable because they answer
+    # different questions -- see `F9` in the generation-lifecycle plan.
+    position_analysis_max_nan_threshold: Optional[float] = None
     mismatch_frequency_range: Sequence[float] = field(default_factory=lambda: [0.05, 0.95])
     mismatch_frequency_layer: str = "mismatch_integer_encoding"
     mismatch_frequency_read_span_layer: str = "read_span_mask"
@@ -2488,6 +2493,7 @@ class ExperimentConfig:
                 )
             ),
             position_max_nan_threshold=merged.get("position_max_nan_threshold", 0.1),
+            position_analysis_max_nan_threshold=merged.get("position_analysis_max_nan_threshold"),
             correlation_matrix_types=merged.get(
                 "correlation_matrix_types", ["pearson", "binary_covariance"]
             ),

--- a/src/smftools/informatics/partition_read.py
+++ b/src/smftools/informatics/partition_read.py
@@ -777,6 +777,15 @@ def _overlay_preprocess_var(
         valid = selected["position_valid"].fillna(False).to_numpy(dtype=bool)
         result.var[f"position_in_{reference}"] = valid
         result.var["N_Reference_strand_with_position"] = valid.astype(np.int64)
+    if "position_valid_analysis" in selected:
+        # Measured over the analysed reads rather than every read the assay
+        # produced. Absent on generations published before `EGL-11`, which is
+        # why consumers fall back rather than assume it.
+        analysed = selected["position_valid_analysis"].fillna(False).to_numpy(dtype=bool)
+        result.var[f"position_in_{reference}_analysis"] = analysed
+    for column in ("valid_count_analysis", "valid_fraction_analysis"):
+        if column in selected:
+            result.var[f"{reference}_{column}"] = selected[column].to_numpy()
 
 
 def _overlay_spatial_read_metrics(

--- a/src/smftools/preprocessing/partitioned_executor.py
+++ b/src/smftools/preprocessing/partitioned_executor.py
@@ -475,6 +475,112 @@ def reduce_partial_coverage(
     return output_path
 
 
+ANALYSIS_COVERAGE_COLUMNS = (
+    "valid_count_analysis",
+    "valid_fraction_analysis",
+    "position_valid_analysis",
+)
+
+
+def analysed_read_population(obs: pd.DataFrame) -> tuple[pd.Series, str]:
+    """Return the read mask analyses actually run on, and which column defined it.
+
+    Preference order is ``passes_dedup`` then ``passes_qc``. ``passes_read_qc``
+    is deliberately not a fallback: it admits reads that later fail
+    modification QC, and on real data that is enough to leave a reference with
+    zero shared positions (see `F9`).
+    """
+    for column in ("passes_dedup", "passes_qc"):
+        if column in obs.columns:
+            return obs[column].fillna(False).astype(bool), column
+    return pd.Series(True, index=obs.index), "all_reads"
+
+
+def reduce_analysis_coverage(
+    catalog_path: str | Path,
+    obs_path: str | Path,
+    var_catalog_path: str | Path,
+    *,
+    minimum_valid_fraction: float,
+) -> Path:
+    """Recompute position coverage over the analysed reads only.
+
+    `reduce_partial_coverage` answers "was this position measured in the reads
+    the assay produced", which is the right question for position statistics and
+    is computed before any QC column exists. It is the wrong question for a
+    shared-position set: reads that fail QC are largely the ones covering least,
+    so they dilute every position and are then discarded anyway.
+
+    This second pass answers "was this position measured in the reads we are
+    analysing", written under its own names so the original meaning survives
+    unchanged and old generations stay comparable.
+    """
+    from ..readwrite import safe_read_zarr
+
+    if not 0 <= minimum_valid_fraction <= 1:
+        raise ValueError("minimum_valid_fraction must be between zero and one")
+    catalog_path = Path(catalog_path)
+    var_catalog_path = Path(var_catalog_path)
+    var_catalog = pd.read_parquet(var_catalog_path)
+    obs = pd.read_parquet(obs_path)
+    mask, population = analysed_read_population(obs)
+    read_column = "read_id" if "read_id" in obs.columns else obs.columns[0]
+    analysed_reads = set(obs.loc[mask, read_column].astype(str))
+    reference_column = "Reference_strand" if "Reference_strand" in obs.columns else None
+    denominators = (
+        obs.loc[mask].groupby(obs.loc[mask, reference_column].astype(str)).size().to_dict()
+        if reference_column
+        else {}
+    )
+
+    counts: dict[tuple[str, int], int] = {}
+    catalog = pd.read_parquet(catalog_path)
+    for record in catalog.to_dict("records"):
+        group_path = catalog_path.parent / str(record["group_path"])
+        result, _ = safe_read_zarr(group_path)
+        reference = str(record["reference"])
+        selected = np.fromiter(
+            (str(name) in analysed_reads for name in result.obs_names),
+            dtype=bool,
+            count=result.n_obs,
+        )
+        if not selected.any():
+            continue
+        matrix = np.asarray(result.X, dtype=float)[selected]
+        positions = np.asarray(result.var_names, dtype=np.int64)
+        per_position = np.sum(~np.isnan(matrix), axis=0).astype(np.int64)
+        for position, count in zip(positions, per_position, strict=True):
+            key = (reference, int(position))
+            counts[key] = counts.get(key, 0) + int(count)
+
+    analysis_counts = [
+        counts.get((str(reference), int(position)), 0)
+        for reference, position in zip(
+            var_catalog["reference"], var_catalog["position"], strict=True
+        )
+    ]
+    var_catalog["valid_count_analysis"] = analysis_counts
+    reference_totals = var_catalog["reference"].astype(str).map(denominators)
+    var_catalog["valid_fraction_analysis"] = np.where(
+        reference_totals.to_numpy(dtype=float) > 0,
+        var_catalog["valid_count_analysis"].to_numpy(dtype=float)
+        / reference_totals.to_numpy(dtype=float),
+        0.0,
+    )
+    var_catalog["position_valid_analysis"] = (
+        var_catalog["valid_fraction_analysis"] >= minimum_valid_fraction
+    )
+    var_catalog.to_parquet(var_catalog_path, index=False)
+    logger.info(
+        "Analysis-population coverage: %d/%d positions valid over %d read(s) selected by %r",
+        int(var_catalog["position_valid_analysis"].sum()),
+        len(var_catalog),
+        len(analysed_reads),
+        population,
+    )
+    return var_catalog_path
+
+
 def write_read_qc_sidecar(spine, cfg, output_path: str | Path) -> Path:
     """Compute read-level QC as an aligned mask without deleting spine rows.
 
@@ -1232,6 +1338,17 @@ def execute_partitioned_preprocessing(
     staging_spine = output_dir / f"{PREPROCESS_SPINE_FILENAME}.partial"
     safe_write_h5ad(derived_spine, staging_spine, backup=False, verbose=False)
     obs_sidecar = reduce_duplicate_reads(staging_spine, obs_sidecar, cfg)
+    # Only now do the QC and dedup columns exist, so only now can position
+    # coverage be measured over the reads analyses actually use.
+    analysis_threshold = getattr(cfg, "position_analysis_max_nan_threshold", None)
+    if analysis_threshold is None:
+        analysis_threshold = cfg.position_max_nan_threshold
+    reduce_analysis_coverage(
+        catalog_path,
+        obs_sidecar,
+        var_catalog,
+        minimum_valid_fraction=1 - float(analysis_threshold),
+    )
     if variant_outputs:
         import json
 

--- a/tests/unit/test_position_validity_analysis.py
+++ b/tests/unit/test_position_validity_analysis.py
@@ -1,0 +1,151 @@
+"""Position validity measured over the analysed reads (`F9` / `EGL-11`).
+
+`reduce_partial_coverage` answers "was this position measured in the reads the
+assay produced" and runs before any QC column exists. That is the right question
+for position statistics and the wrong one for a shared-position set: reads that
+fail QC are largely the ones covering least, so they dilute every position and
+are then discarded anyway.
+
+These tests pin the distinction. The fixture is built so that a position's
+apparent validity is decided *entirely* by reads that QC throws away.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from smftools.preprocessing.partitioned_executor import (
+    ANALYSIS_COVERAGE_COLUMNS,
+    analysed_read_population,
+    reduce_analysis_coverage,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_task(tmp_path, *, read_ids, matrix, positions, reference="ref_top"):
+    """Write one task store the reducer can read, plus its catalog row."""
+    import anndata as ad
+
+    from smftools.readwrite import safe_write_zarr
+
+    adata = ad.AnnData(
+        X=np.asarray(matrix, dtype=float),
+        obs=pd.DataFrame(index=[str(r) for r in read_ids]),
+        var=pd.DataFrame(index=[str(p) for p in positions]),
+    )
+    group = tmp_path / "task-1.zarr"
+    safe_write_zarr(adata, group, backup=False, verbose=False, zarr_format=3)
+    catalog = tmp_path / "catalog.parquet"
+    pd.DataFrame(
+        [{"group_path": group.name, "reference": reference, "n_positions": len(positions)}]
+    ).to_parquet(catalog, index=False)
+    return catalog
+
+
+def _write_var_catalog(tmp_path, positions, reference="ref_top"):
+    path = tmp_path / "var.parquet"
+    pd.DataFrame(
+        {
+            "reference": [reference] * len(positions),
+            "position": list(positions),
+            "valid_count": [0] * len(positions),
+            "valid_fraction": [0.0] * len(positions),
+            "position_valid": [False] * len(positions),
+        }
+    ).to_parquet(path, index=False)
+    return path
+
+
+def _write_obs(tmp_path, *, read_ids, passing, reference="ref_top"):
+    path = tmp_path / "obs.parquet"
+    pd.DataFrame(
+        {
+            "read_id": [str(r) for r in read_ids],
+            "Reference_strand": [reference] * len(read_ids),
+            "passes_read_qc": [True] * len(read_ids),
+            "passes_qc": list(passing),
+            "passes_dedup": list(passing),
+        }
+    ).to_parquet(path, index=False)
+    return path
+
+
+def test_a_position_carried_by_discarded_reads_is_invalid_for_analysis(tmp_path):
+    """The defect, stated as a test.
+
+    Position 0 is measured in every read, but only the failing reads carry it in
+    a way that would matter; position 1 is measured *only* by reads that QC
+    discards. Over the assay-wide population position 1 looks well covered; over
+    the analysed population it is not covered at all.
+    """
+    read_ids = [f"read{i}" for i in range(10)]
+    passing = [True] * 2 + [False] * 8
+    # position 0: measured in the 2 analysed reads. position 1: measured only in
+    # the 8 discarded ones.
+    matrix = [[1.0, np.nan] if index < 2 else [1.0, 1.0] for index in range(10)]
+    catalog = _write_task(tmp_path, read_ids=read_ids, matrix=matrix, positions=[0, 1])
+    var_catalog = _write_var_catalog(tmp_path, [0, 1])
+    obs = _write_obs(tmp_path, read_ids=read_ids, passing=passing)
+
+    reduce_analysis_coverage(catalog, obs, var_catalog, minimum_valid_fraction=0.8)
+
+    result = pd.read_parquet(var_catalog).set_index("position")
+    assert set(ANALYSIS_COVERAGE_COLUMNS) <= set(result.columns)
+    # Measured in both analysed reads.
+    assert result.loc[0, "valid_count_analysis"] == 2
+    assert bool(result.loc[0, "position_valid_analysis"]) is True
+    # Measured only by reads that are thrown away.
+    assert result.loc[1, "valid_count_analysis"] == 0
+    assert bool(result.loc[1, "position_valid_analysis"]) is False
+    # The assay-wide columns are untouched, so the original meaning survives.
+    assert result["position_valid"].tolist() == [False, False]
+
+
+def test_the_analysis_denominator_excludes_discarded_reads(tmp_path):
+    """Diluting reads must leave the fraction alone, not depress it."""
+    read_ids = [f"read{i}" for i in range(10)]
+    passing = [True] * 2 + [False] * 8
+    # Position 0 is measured in the 2 analysed reads and in none of the others.
+    matrix = [[1.0] if index < 2 else [np.nan] for index in range(10)]
+    catalog = _write_task(tmp_path, read_ids=read_ids, matrix=matrix, positions=[0])
+    var_catalog = _write_var_catalog(tmp_path, [0])
+    obs = _write_obs(tmp_path, read_ids=read_ids, passing=passing)
+
+    reduce_analysis_coverage(catalog, obs, var_catalog, minimum_valid_fraction=0.8)
+
+    result = pd.read_parquet(var_catalog).iloc[0]
+    # 2/2 analysed reads, not 2/10 of everything the assay produced.
+    assert result["valid_fraction_analysis"] == pytest.approx(1.0)
+    assert bool(result["position_valid_analysis"]) is True
+
+
+def test_read_qc_alone_is_not_the_analysis_population(tmp_path):
+    """`passes_read_qc` is deliberately not a fallback.
+
+    On real data it admits reads that later fail modification QC, and that was
+    enough to leave a reference with zero shared positions.
+    """
+    obs = pd.DataFrame(
+        {
+            "read_id": ["a", "b"],
+            "passes_read_qc": [True, True],
+            "passes_qc": [True, False],
+            "passes_dedup": [True, False],
+        }
+    )
+    mask, population = analysed_read_population(obs)
+    assert population == "passes_dedup"
+    assert mask.tolist() == [True, False]
+
+    mask, population = analysed_read_population(obs.drop(columns=["passes_dedup"]))
+    assert population == "passes_qc"
+    assert mask.tolist() == [True, False]
+
+    # Read QC alone never selects the population, even when it is all that is
+    # present -- the reducer falls through to every read and says so.
+    mask, population = analysed_read_population(obs.drop(columns=["passes_dedup", "passes_qc"]))
+    assert population == "all_reads"
+    assert mask.tolist() == [True, True]


### PR DESCRIPTION
Found by running the `241213` pilot under current `main`: its `latent` stage failed with "no units meeting latent_min_reads", and `position_valid` was False for all 18,746 positions.

The cause is a denominator, not a threshold. `reduce_partial_coverage` counts non-NaN values over every read in the task and divides by the reference's planned read count, and it runs before `append_modification_qc_mask` and `reduce_duplicate_reads` exist -- so it structurally cannot filter. Reads that fail QC are largely the ones covering least of the amplicon, so they dilute every position and are then discarded anyway.

Measured on `241213`, positions clearing the 0.8 threshold:

    6BALB_cJ_top   all reads 9,253 ->     0      passes_dedup 1,929 -> 1,361
    6B6_top        all reads 9,885 ->     0      passes_dedup 1,932 -> 1,364

About 1,360 real positions per reference -- ~29% of each ~4,690-position reference -- were reading as zero.

Add a second pass, `reduce_analysis_coverage`, after dedup, writing `valid_count_analysis`, `valid_fraction_analysis`, and `position_valid_analysis`. Moving the original reduction was not an option: it feeds spine construction, and `reduce_duplicate_reads` needs that spine on disk. The staging-spine dance guarding that ordering exists because of a real incident, and is left alone.

`position_valid` keeps its meaning -- "measured in the reads the assay produced" -- which is the right question for `position_stats` and is what every published generation already recorded. Redefining it would make old and new generations incomparable while both claimed the same schema. The new column is additive; old generations lack it and say so.

The population is `passes_dedup`, else `passes_qc`. `passes_read_qc` is deliberately not a fallback: on this data `6B6_top` still yields zero positions under read QC alone and only clears under `passes_qc`.

`position_analysis_max_nan_threshold` is separate from `position_max_nan_threshold` because one knob was answering two different questions; it inherits the old value when unset.

Latent prefers the new column and, on a generation published before this, falls back to the old one *and says which it used* rather than failing or silently using the diluted quantity.

The lead test states the defect rather than the fix: a position measured only by reads QC discards must read valid for the assay and invalid for analysis.

31 tests pass across the preprocess-executor and direct-modality suites; Ruff check/format clean. Known limits, both recorded in the plan: existing generations still need preprocess re-run to gain the column, and this pass reads task matrices where the original read only `var`, which is worth measuring on `260420` before assuming it is free.