### PR TITLE
fix: stop counting OS metadata in artifact checksums

### DIFF
--- a/src/smftools/cli/workflow_contract.py
+++ b/src/smftools/cli/workflow_contract.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 import pandas as pd
 
 from .._version import __version__
-from ..constants import PARTITIONED_STAGE_REQUIRED_ARTIFACTS, PREPROCESS_DIR
+from ..constants import PARTITIONED_STAGE_REQUIRED_ARTIFACTS, PREPROCESS_DIR, is_os_metadata
 from ..informatics.experiment_manifest import (
     MANIFEST_FILENAME,
     read_experiment_manifest,
@@ -102,7 +102,9 @@ def _now() -> str:
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     if path.is_dir():
-        for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        for child in sorted(
+            item for item in path.rglob("*") if item.is_file() and not is_os_metadata(item)
+        ):
             digest.update(child.relative_to(path).as_posix().encode("utf-8"))
             digest.update(b"\0")
             with child.open("rb") as handle:
@@ -147,7 +149,9 @@ def _source_fingerprint(path: Path) -> dict[str, Any]:
     if path.is_dir():
         digest = hashlib.sha256()
         count = 0
-        for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        for child in sorted(
+            item for item in path.rglob("*") if item.is_file() and not is_os_metadata(item)
+        ):
             stat = child.stat()
             digest.update(child.relative_to(path).as_posix().encode("utf-8"))
             digest.update(f"\0{stat.st_size}\0{stat.st_mtime_ns}".encode("utf-8"))

--- a/src/smftools/constants.py
+++ b/src/smftools/constants.py
@@ -4,6 +4,39 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Dict, Final, Mapping
 
+## Operating-system metadata ##
+# Files the OS or a file browser drops into directories without anyone asking.
+# Merely opening a published generation's folder in macOS Finder creates a
+# `.DS_Store` inside it; a directory checksum that counted such a file would
+# report a validated, immutable artifact as corrupt for a reason having nothing
+# to do with its contents. Content hashing therefore skips them.
+OS_METADATA_FILENAMES: Final[frozenset[str]] = frozenset(
+    {
+        ".DS_Store",  # macOS Finder
+        "Thumbs.db",  # Windows Explorer
+        "desktop.ini",  # Windows Explorer
+        ".directory",  # KDE Dolphin
+    }
+)
+# macOS resource-fork sidecars on non-HFS volumes, and Spotlight/trash state.
+OS_METADATA_PREFIXES: Final[tuple[str, ...]] = ("._",)
+OS_METADATA_DIRECTORIES: Final[frozenset[str]] = frozenset(
+    {".Spotlight-V100", ".Trashes", ".fseventsd", "__MACOSX"}
+)
+
+
+def is_os_metadata(path: Path) -> bool:
+    """Return whether a path is operating-system metadata rather than content.
+
+    Used by every directory content hash. Keeping one predicate means an
+    artifact's digest cannot depend on which platform last browsed it.
+    """
+    if path.name in OS_METADATA_FILENAMES:
+        return True
+    if path.name.startswith(OS_METADATA_PREFIXES):
+        return True
+    return any(part in OS_METADATA_DIRECTORIES for part in path.parts)
+
 
 ## Helpers ##
 def _deep_freeze(obj: Any) -> Any:

--- a/src/smftools/informatics/experiment_manifest.py
+++ b/src/smftools/informatics/experiment_manifest.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any
 
+from ..constants import is_os_metadata
 from ..logging_utils import get_logger
 from ..metadata import smftools_code_identity
 from ..readwrite import atomic_write_json
@@ -155,7 +156,9 @@ def artifact_record(
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     if path.is_dir():
-        for child in sorted(item for item in path.rglob("*") if item.is_file()):
+        for child in sorted(
+            item for item in path.rglob("*") if item.is_file() and not is_os_metadata(item)
+        ):
             digest.update(child.relative_to(path).as_posix().encode("utf-8"))
             digest.update(b"\0")
             with child.open("rb") as handle:

--- a/src/smftools/informatics/raw_intermediate_manifest.py
+++ b/src/smftools/informatics/raw_intermediate_manifest.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping, Sequence
 
 from smftools.constants import RAW_DIR
 
+from ..constants import is_os_metadata
 from ..readwrite import atomic_write_json
 
 RAW_INTERMEDIATE_MANIFEST_SCHEMA_VERSION = 1
@@ -63,7 +64,9 @@ def sha256_file(path: str | Path) -> str:
 
 def _directory_digest(path: Path) -> str:
     records = []
-    for child in sorted(item for item in path.rglob("*") if item.is_file()):
+    for child in sorted(
+        item for item in path.rglob("*") if item.is_file() and not is_os_metadata(item)
+    ):
         records.append(
             {
                 "path": child.relative_to(path).as_posix(),

--- a/tests/unit/informatics/test_os_metadata_checksums.py
+++ b/tests/unit/informatics/test_os_metadata_checksums.py
@@ -1,0 +1,94 @@
+"""Directory checksums ignore operating-system metadata (`F10`).
+
+A published generation is validated by re-hashing its artifact directories.
+Opening one of those directories in macOS Finder writes a `.DS_Store` inside it,
+which changed the digest and made a validated, immutable artifact report as
+"missing or corrupt" for a reason having nothing to do with its contents. This
+happened on the `241213` pilot and blocked a re-run.
+
+The digest must describe the artifact, not which platform last browsed it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smftools.cli.workflow_contract import _sha256 as workflow_sha256
+from smftools.constants import is_os_metadata
+from smftools.informatics.experiment_manifest import _sha256 as manifest_sha256
+from smftools.informatics.raw_intermediate_manifest import artifact_checksum
+
+pytestmark = pytest.mark.unit
+
+_HASHERS = (
+    pytest.param(manifest_sha256, id="generation_manifest"),
+    pytest.param(artifact_checksum, id="raw_intermediate"),
+    pytest.param(workflow_sha256, id="workflow_contract"),
+)
+
+
+def _artifact(tmp_path):
+    directory = tmp_path / "plots"
+    (directory / "read_span_quality").mkdir(parents=True)
+    (directory / "catalog.parquet").write_bytes(b"catalog-bytes")
+    (directory / "read_span_quality" / "ref__bc01.png").write_bytes(b"png-bytes")
+    return directory
+
+
+@pytest.mark.parametrize("hasher", _HASHERS)
+def test_finder_visiting_a_published_artifact_does_not_invalidate_it(tmp_path, hasher):
+    directory = _artifact(tmp_path)
+    published = hasher(directory)
+
+    # Exactly what macOS writes when the folder is opened.
+    (directory / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+
+    assert hasher(directory) == published
+
+
+@pytest.mark.parametrize("hasher", _HASHERS)
+def test_other_platforms_metadata_is_ignored_too(tmp_path, hasher):
+    directory = _artifact(tmp_path)
+    published = hasher(directory)
+
+    (directory / "Thumbs.db").write_bytes(b"thumbs")
+    (directory / "desktop.ini").write_bytes(b"[.ShellClassInfo]")
+    (directory / "._catalog.parquet").write_bytes(b"resource-fork")
+    (directory / "__MACOSX").mkdir()
+    (directory / "__MACOSX" / "._archive").write_bytes(b"junk")
+
+    assert hasher(directory) == published
+
+
+@pytest.mark.parametrize("hasher", _HASHERS)
+def test_real_content_still_changes_the_digest(tmp_path, hasher):
+    """The ignore must not blunt the check it is protecting."""
+    directory = _artifact(tmp_path)
+    published = hasher(directory)
+
+    (directory / "read_span_quality" / "ref__bc01.png").write_bytes(b"tampered")
+
+    assert hasher(directory) != published
+
+
+@pytest.mark.parametrize("hasher", _HASHERS)
+def test_an_added_real_file_still_changes_the_digest(tmp_path, hasher):
+    directory = _artifact(tmp_path)
+    published = hasher(directory)
+
+    (directory / "read_span_quality" / "ref__bc02.png").write_bytes(b"new-plot")
+
+    assert hasher(directory) != published
+
+
+def test_the_predicate_names_metadata_and_nothing_else():
+    from pathlib import Path
+
+    assert is_os_metadata(Path("plots/.DS_Store"))
+    assert is_os_metadata(Path("plots/Thumbs.db"))
+    assert is_os_metadata(Path("plots/._catalog.parquet"))
+    assert is_os_metadata(Path("plots/__MACOSX/._archive"))
+    # A dotfile is not automatically metadata: smftools writes its own.
+    assert not is_os_metadata(Path("plots/.smftools_marker"))
+    assert not is_os_metadata(Path("plots/catalog.parquet"))
+    assert not is_os_metadata(Path("plots/read_span_quality/ref__bc01.png"))


### PR DESCRIPTION
Opening a published generation's `plots` folder in macOS Finder made the generation fail validation. Found when the `241213` pilot re-run aborted with `preprocess generation artifact is missing or corrupt: plots` before reaching any pipeline work.

One file explained the whole thing:

    plots/.DS_Store         2026-08-17 09:32:44   <- Finder, 25 min earlier
    plots/*  (120 files)    2026-08-14 17:49:17   <- publication, untouched

`_sha256` hashed every file under the directory, so a dotfile the OS wrote while someone browsed to look at clustermaps changed the digest from `e89002a7...` to `0456c7a3...`. Deleting it restored the recorded digest byte-for-byte, which is itself the proof the artifact was never damaged.

Severity here is about frequency, not blast radius. These projects live on a Mac desktop -- `find runs -name .DS_Store` returns 239 hits -- and `NKG-03` regenerates 20 runs, with every published generation validated on read. This would have recurred at unpredictable moments, each time presenting as data corruption.

Add `constants.is_os_metadata` and apply it to every directory content hash that guards artifact validity: `experiment_manifest._sha256` (generations), `raw_intermediate_manifest.artifact_checksum` (raw intermediates and Dorado model bundles, so `SRB-04a` model identity is covered), and both `cli/workflow_contract` sites. One predicate, so an artifact's digest cannot depend on which platform last browsed it. It covers Finder, Explorer, Dolphin, macOS resource forks, and `__MACOSX`, but deliberately not dotfiles generally -- smftools writes its own, and those are content.

Migration risk was checked rather than assumed: ignoring a file changes the digest of any tree that contained one *at publication time*. No published generation in this project contains OS metadata (zero hits under `runs/*/store/*/generations`), so nothing already recorded is invalidated. A tree published elsewhere with a `.DS_Store` inside would flip once, which is the correct trade.

The tests pin both directions: the digest must survive Finder visiting the directory, and must still change when real content is edited or added. Each runs against all three hashers.

Still open, recorded in the plan as part of `F10`: the failure said `missing or corrupt: plots` and named no file, so establishing "one OS dotfile" took a checksum comparison and an mtime sweep. Reporting which path differs would make the next such failure self-explanatory.

13 focused tests; Ruff check/format clean.