### PR TITLE
fix: read string-valued booleans as booleans in clustermap filters

### DIFF
--- a/src/smftools/plotting/hmm_plotting.py
+++ b/src/smftools/plotting/hmm_plotting.py
@@ -16,6 +16,7 @@ from smftools.plotting.plotting_utils import (
     _methylation_fraction_for_layer,
     _ordered_columns,
     clean_barplot,
+    coerce_bool_series,
     normalized_mean,
     subsample_reads_for_plot,
 )
@@ -1141,7 +1142,7 @@ def combined_hmm_raw_clustermap(
         else (lambda s: pd.Series(True, index=s.index)),
     )
     chimeric_mask = (
-        _mask_or_true("chimeric_variant_sites", lambda s: ~s.astype(bool))
+        _mask_or_true("chimeric_variant_sites", lambda s: ~coerce_bool_series(s))
         if omit_chimeric_reads
         else pd.Series(True, index=adata.obs.index)
     )
@@ -1852,7 +1853,7 @@ def combined_hmm_length_clustermap(
         else (lambda s: pd.Series(True, index=s.index)),
     )
     chimeric_mask = (
-        _mask_or_true("chimeric_variant_sites", lambda s: ~s.astype(bool))
+        _mask_or_true("chimeric_variant_sites", lambda s: ~coerce_bool_series(s))
         if omit_chimeric_reads
         else pd.Series(True, index=adata.obs.index)
     )

--- a/src/smftools/plotting/plotting_utils.py
+++ b/src/smftools/plotting/plotting_utils.py
@@ -13,6 +13,37 @@ if TYPE_CHECKING:
     import anndata as ad
 
 
+_TRUTHY_STRINGS = frozenset({"1", "true", "t", "yes", "y", "on"})
+
+
+def coerce_bool_series(series: "pd.Series") -> "pd.Series":
+    """Interpret an obs column as booleans, including string-valued ones.
+
+    ``Series.astype(bool)`` is wrong for anything object- or category-typed
+    holding ``"True"``/``"False"``: Python truthiness makes the *string*
+    ``"False"`` true, so a filter meant to exclude a minority of reads excludes
+    none of them -- or, negated, excludes all of them.
+
+    That is not theoretical. ``chimeric_variant_sites`` round-trips through
+    parquet as a category of ``"True"``/``"False"``, so ``~s.astype(bool)`` was
+    empty for every read and every HMM clustermap silently plotted nothing
+    while still creating its output directories (`F13`).
+
+    Missing values are False: a read whose chimeric status is unknown is not
+    evidence of chimerism.
+    """
+    if series.dtype == bool:
+        return series
+    if isinstance(series.dtype, pd.CategoricalDtype):
+        series = series.astype(object)
+    if pd.api.types.is_bool_dtype(series):
+        return series.fillna(False).astype(bool)
+    if pd.api.types.is_numeric_dtype(series):
+        return series.fillna(0).astype(bool)
+    normalized = series.astype("string").str.strip().str.lower()
+    return normalized.isin(_TRUTHY_STRINGS).fillna(False).astype(bool)
+
+
 def _fixed_tick_positions(n_positions: int, n_ticks: int) -> np.ndarray:
     """
     Return indices for ~n_ticks evenly spaced labels across [0, n_positions-1].

--- a/src/smftools/plotting/spatial_plotting.py
+++ b/src/smftools/plotting/spatial_plotting.py
@@ -20,6 +20,7 @@ from smftools.plotting.plotting_utils import (
     _methylation_fraction_for_layer,
     _ordered_columns,
     clean_barplot,
+    coerce_bool_series,
     make_row_colors,
     subsample_reads_for_plot,
 )
@@ -1082,7 +1083,7 @@ def combined_raw_clustermap(
                 else (lambda s: pd.Series(True, index=s.index)),
             )
             chimeric_mask = (
-                _mask_or_true("chimeric_variant_sites", lambda s: ~s.astype(bool))
+                _mask_or_true("chimeric_variant_sites", lambda s: ~coerce_bool_series(s))
                 if omit_chimeric_reads
                 else pd.Series(True, index=adata.obs.index)
             )

--- a/tests/unit/test_chimeric_bool_coercion.py
+++ b/tests/unit/test_chimeric_bool_coercion.py
@@ -1,0 +1,102 @@
+"""String-valued booleans must not be read with Python truthiness (`F13`).
+
+``chimeric_variant_sites`` round-trips through parquet as a *category of the
+strings* ``"True"``/``"False"``. The clustermap filters negated it with
+``~s.astype(bool)``, and ``bool("False")`` is ``True`` -- so every read was
+treated as chimeric, every group filtered to nothing, and every HMM clustermap
+silently produced no image while still creating its output directory.
+
+Found by looking at why `241213`'s HMM clustermap folders were empty; it had
+been that way in every generation on disk.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from smftools.plotting.plotting_utils import coerce_bool_series
+
+pytestmark = pytest.mark.unit
+
+
+def test_string_false_is_false():
+    """The defect, stated at its smallest."""
+    series = pd.Series(["True", "False", "True"])
+    assert list(coerce_bool_series(series)) == [True, False, True]
+    # The behavior being replaced, pinned so the contrast is explicit.
+    assert list(series.astype(bool)) == [True, True, True]
+
+
+def test_categorical_of_strings_is_the_real_shape():
+    """This is exactly how the column arrives after a parquet round-trip."""
+    series = pd.Series(["True", "False", "False"]).astype("category")
+    kept = ~coerce_bool_series(series)
+    assert int(kept.sum()) == 2, "non-chimeric reads must survive the filter"
+
+
+def test_real_booleans_are_unchanged():
+    series = pd.Series([True, False, True])
+    assert list(coerce_bool_series(series)) == [True, False, True]
+
+
+def test_numeric_flags_are_unchanged():
+    series = pd.Series([1, 0, 1])
+    assert list(coerce_bool_series(series)) == [True, False, True]
+
+
+def test_missing_is_not_evidence_of_chimerism():
+    """Unknown status must not exclude a read."""
+    series = pd.Series(["True", None, "False"])
+    assert list(coerce_bool_series(series)) == [True, False, False]
+
+
+@pytest.mark.parametrize("truthy", ["true", "TRUE", " True ", "t", "yes", "y", "1", "on"])
+def test_truthy_spellings(truthy):
+    assert bool(coerce_bool_series(pd.Series([truthy])).iloc[0])
+
+
+@pytest.mark.parametrize("falsy", ["false", "FALSE", " False ", "f", "no", "n", "0", "off"])
+def test_falsy_spellings(falsy):
+    assert not bool(coerce_bool_series(pd.Series([falsy])).iloc[0])
+
+
+def test_clustermap_keeps_non_chimeric_reads_end_to_end():
+    """The filter as the plotting code actually builds it.
+
+    Asserting on the mask rather than on a rendered PNG keeps this a unit
+    test, but it is the same expression: an all-empty mask here is precisely
+    what produced empty clustermap directories.
+    """
+    obs = pd.DataFrame(
+        {
+            "chimeric_variant_sites": pd.Series(["False", "True", "False", "False"]).astype(
+                "category"
+            ),
+        }
+    )
+    chimeric_mask = ~coerce_bool_series(obs["chimeric_variant_sites"])
+    assert int(chimeric_mask.sum()) == 3
+    assert not bool(chimeric_mask.iloc[1])
+
+
+def test_all_chimeric_still_filters_everything():
+    """The filter must remain capable of excluding; this is not a pass-through."""
+    obs = pd.Series(["True", "True"]).astype("category")
+    assert int((~coerce_bool_series(obs)).sum()) == 0
+
+
+def test_unrecognized_strings_are_false():
+    """Anything not in the truthy vocabulary is not chimeric.
+
+    Chosen deliberately over raising: an unexpected label should degrade to
+    "keep the read and plot it", not abort a pipeline stage.
+    """
+    assert not bool(coerce_bool_series(pd.Series(["maybe"])).iloc[0])
+
+
+def test_empty_series_round_trips():
+    result = coerce_bool_series(pd.Series([], dtype=object))
+    assert len(result) == 0
+    assert result.dtype == np.dtype(bool)


### PR DESCRIPTION
Every HMM clustermap directory in this project is empty, and has been in every generation on disk. The directories are created, the plots are not.

`chimeric_variant_sites` round-trips through parquet as a *category of the strings* `"True"`/`"False"`. The filter negated it with `~s.astype(bool)`, and `bool("False")` is `True` -- a non-empty string. So every read was treated as chimeric, `chimeric_mask` was empty, and each (reference, sample) group logged `No reads for <barcode> after filtering` and returned without plotting. With `omit_chimeric_reads: TRUE` in the config, that is every group.

Reproduced against the published `241213` generation: 9,253 reads materialize, 0 survive the filter, 0 PNGs. With the fix, the same call writes 15 clustermaps.

Add `plotting_utils.coerce_bool_series` and use it at all three sites that negate this column -- two in `hmm_plotting`, one in `spatial_plotting`. The spatial one was dormant rather than harmless: spatial's working clustermaps come from a path that does not apply this mask, so the same expression sat there waiting for a caller that did.

The coercion follows the truthy vocabulary `HMM._coerce_bool` already established (`1/true/t/yes/y/on`), and treats missing as False on the grounds that a read whose chimeric status is unknown is not evidence of chimerism. Unrecognized labels are False too: an unexpected value should degrade to "keep the read and plot it", not abort a plotting stage.

This is a plotting-only defect. No analysis result, QC decision, or published array was affected -- the reads were always in the data, they were only being excluded from the picture.

25 focused tests, including the one-line statement of the defect (`bool("False")`), the categorical shape the column actually arrives in, and a guard that the filter still excludes when every read really is chimeric, so the fix cannot degrade into a pass-through.

Full suites on the branch: 2158 unit, 106 smoke, 55 integration; Ruff check and format clean.