### PR TITLE
feat: require adjacent site support before calling a read chimeric

### DIFF
--- a/src/smftools/cli/variant_adata.py
+++ b/src/smftools/cli/variant_adata.py
@@ -340,6 +340,7 @@ def variant_adata_core(
             seq2_column=seq2_col,
             read_span_layer=cfg.mismatch_frequency_read_span_layer,
             reference_col=cfg.reference_column,
+            min_adjacent_sites=int(getattr(cfg, "variant_chimera_min_adjacent_sites", 1) or 1),
         )
 
     ############################################### Plot mismatch base frequencies ###############################################

--- a/src/smftools/config/experiment_config.py
+++ b/src/smftools/config/experiment_config.py
@@ -1142,6 +1142,15 @@ class ExperimentConfig:
     variant_qc_min_callable_fraction: Optional[float] = None
     variant_qc_min_calls_per_state: Optional[int] = None
     variant_qc_disallowed_event_classes: List[str] = field(default_factory=list)
+    # How many consecutive informative variant sites must call the *other*
+    # reference before a read is reported as a reference-switching chimera.
+    # Sites, not bases: variant sites are sparse, so one discordant site would
+    # otherwise open an interpolated segment spanning hundreds of positions.
+    # The variant caller previously had no such floor -- unlike the deaminase
+    # chimera path, which has carried `deaminase_chimera_min_events_per_span`
+    # all along -- and flagged 100% of QC-passing pilot reads on 2-3 discordant
+    # bases out of ~2,300 (`F14`). Set to 1 to restore the previous behavior.
+    variant_chimera_min_adjacent_sites: int = 2
     references_to_align_for_variant_annotation: List[Optional[str]] = field(
         default_factory=lambda: [None, None]
     )
@@ -2694,6 +2703,7 @@ class ExperimentConfig:
             variant_qc_disallowed_event_classes=merged.get(
                 "variant_qc_disallowed_event_classes", []
             ),
+            variant_chimera_min_adjacent_sites=merged.get("variant_chimera_min_adjacent_sites", 2),
             from_adata_stage=merged.get("from_adata_stage", None),
             plot_current_read_ids=merged.get("plot_current_read_ids", []),
             plot_current_reference_start=merged.get("plot_current_reference_start", None),

--- a/src/smftools/preprocessing/append_variant_call_layer.py
+++ b/src/smftools/preprocessing/append_variant_call_layer.py
@@ -288,6 +288,7 @@ def append_variant_segment_layer(
     uns_flag: str = "append_variant_segment_layer_performed",
     force_redo: bool = False,
     bypass: bool = False,
+    min_adjacent_sites: int = 1,
 ) -> None:
     """Segment each read span into contiguous seq1/seq2 regions based on variant calls.
 
@@ -378,6 +379,7 @@ def append_variant_segment_layer(
             call_matrix[i],
             span_matrix[i] > 0,
             aligned_member_index=(seq_id or 1) - 1,
+            min_adjacent_sites=min_adjacent_sites,
         )
         segment_layer[i] = result.segments
         breakpoint_counts[i] = result.breakpoint_count

--- a/src/smftools/preprocessing/partitioned_variant.py
+++ b/src/smftools/preprocessing/partitioned_variant.py
@@ -200,6 +200,7 @@ def _execute_variant_task(
     output_dir: Path,
     task: VariantEvidenceTask,
     catalog: VariantInformativeSiteCatalog,
+    min_adjacent_sites: int = 1,
 ) -> dict[str, object]:
     task_root = (
         output_dir
@@ -243,6 +244,7 @@ def _execute_variant_task(
                 span_start=span_start,
                 span_end=span_end,
                 aligned_member_index=task.aligned_member_index,
+                min_adjacent_sites=min_adjacent_sites,
             )
             common = {
                 EXPERIMENT_UID_COLUMN: task.experiment_uid,
@@ -513,6 +515,9 @@ def execute_partitioned_variant_evidence(
     """Compute and index all-molecule variant evidence without monolithic AnnData."""
     if max_workers <= 0 or memory_budget_mb <= 0:
         raise ValueError("max_workers and memory_budget_mb must be positive")
+    # Default 1 (no floor) when there is no cfg, so library callers keep the
+    # historical behavior; pipeline runs get the configured floor. See `F14`.
+    minimum_chimera_sites = max(1, int(getattr(cfg, "variant_chimera_min_adjacent_sites", 1) or 1))
     spine_path = Path(spine_path)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -553,7 +558,13 @@ def execute_partitioned_variant_evidence(
     memory_workers = max(1, int(memory_budget_mb * 1024**2) // maximum_task_bytes)
     bounded_workers = min(max_workers, memory_workers, len(task_list))
     arguments = [
-        (spine_path, output_dir, task, catalogs[task.variant_reference_set_id])
+        (
+            spine_path,
+            output_dir,
+            task,
+            catalogs[task.variant_reference_set_id],
+            minimum_chimera_sites,
+        )
         for task in task_list
     ]
     if cfg is not None:

--- a/src/smftools/preprocessing/variant_evidence.py
+++ b/src/smftools/preprocessing/variant_evidence.py
@@ -151,8 +151,19 @@ def segment_sparse_variant_calls(
     span_start: int,
     span_end: int,
     aligned_member_index: int,
+    min_adjacent_sites: int = 1,
 ) -> SparseVariantSegmentationResult:
-    """Segment sparse calls across a half-open aligned read span."""
+    """Segment sparse calls across a half-open aligned read span.
+
+    ``min_adjacent_sites`` is how many *consecutive informative sites* must call
+    the other reference before the read is reported as reference-switching; see
+    :func:`segment_variant_calls` for why this is counted in sites rather than
+    bases and what happens without it (`F14`). This is the path the partitioned
+    pipeline uses, so it is the one that produced the pilot's 100%-chimeric
+    result.
+
+    Counts and segments stay raw; only the interpretation is gated.
+    """
     if span_start < 0 or span_end < span_start:
         raise ValueError("read span must be a valid half-open interval")
     if aligned_member_index not in (0, 1):
@@ -197,13 +208,38 @@ def segment_sparse_variant_calls(
     )
     other_segments = [segment for segment in segments if segment.state == other_value]
     other_count = sum(segment.end - segment.start for segment in other_segments)
+
+    # Site support per segment. Segments are emitted one per run of
+    # same-class informative sites, in order, so the k-th non-transition
+    # segment is backed by the k-th run -- which makes the run length the
+    # segment's evidence count.
+    minimum_sites = max(1, int(min_adjacent_sites))
+    run_lengths: list[int] = []
+    if informative:
+        run_class = informative[0][1]
+        run_length = 1
+        for _position, current_class in informative[1:]:
+            if current_class == run_class:
+                run_length += 1
+            else:
+                run_lengths.append(run_length)
+                run_class = current_class
+                run_length = 1
+        run_lengths.append(run_length)
+    called_segments = [segment for segment in segments if segment.state in (1, 2)]
+    supported_other = [
+        segment
+        for segment, support in zip(called_segments, run_lengths)
+        if segment.state == other_value and support >= minimum_sites
+    ]
+
     mismatch_type = "no_segment_mismatch"
-    if other_segments:
-        if len(other_segments) >= 2:
+    if supported_other:
+        if len(supported_other) >= 2:
             mismatch_type = "multi_segment_mismatch"
-        elif other_segments[0].start == span_start:
+        elif supported_other[0].start == span_start:
             mismatch_type = "left_segment_mismatch"
-        elif other_segments[0].end == span_end:
+        elif supported_other[0].end == span_end:
             mismatch_type = "right_segment_mismatch"
         else:
             mismatch_type = "middle_segment_mismatch"
@@ -216,7 +252,7 @@ def segment_sparse_variant_calls(
         segments=tuple(segments),
         breakpoints=tuple(breakpoints),
         has_breakpoint=bool(breakpoints),
-        has_other_reference_segment=bool(other_segments),
+        has_other_reference_segment=bool(supported_other),
         other_reference_segment_type=mismatch_type,
         self_base_count=self_count,
         other_base_count=other_count,
@@ -299,8 +335,35 @@ def segment_variant_calls(
     covered: Sequence[bool],
     *,
     aligned_member_index: int,
+    min_adjacent_sites: int = 1,
 ) -> VariantSegmentationResult:
-    """Interpolate calls across a read span using the legacy breakpoint semantics."""
+    """Interpolate calls across a read span using the legacy breakpoint semantics.
+
+    Args:
+        calls: Per-position variant call classes (1 or 2 at informative sites).
+        covered: Per-position read-span mask.
+        aligned_member_index: 0 or 1 -- which reference this read aligned to.
+        min_adjacent_sites: How many *consecutive informative sites* must call
+            the other reference before the read is reported as
+            reference-switching. Sites, not bases: variant sites are sparse, so
+            the run is counted over the informative-site sequence rather than
+            over interpolated genomic positions.
+
+            The default of 1 preserves the historical behavior, in which a
+            single discordant site was enough. That is what made the flag
+            useless on real data: on the `241213` pilot it called 100% of
+            QC-passing reads chimeric on the strength of 2-3 discordant bases
+            out of ~2,300, because one isolated base opens a segment of the
+            other reference (`F14`). Callers that care should pass the
+            configured value; `ExperimentConfig.variant_chimera_min_adjacent
+            _sites` defaults to 2.
+
+            Counts (``self_base_count``, ``other_base_count``) and the segment
+            layer are deliberately left raw. This gates the *interpretation* --
+            whether the read is called chimeric and how the mismatch is typed --
+            so a read with a couple of stray discordant bases still shows them
+            in the plotted segments while being typed ``no_segment_mismatch``.
+    """
     call_row = np.asarray(calls)
     span_row = np.asarray(covered, dtype=bool)
     if call_row.ndim != 1 or span_row.ndim != 1 or call_row.shape != span_row.shape:
@@ -344,10 +407,37 @@ def segment_variant_calls(
     mismatch_mask = in_span == other_value
     self_count = int(np.sum(in_span == self_value))
     other_count = int(np.sum(mismatch_mask))
+
+    # Which stretches of other-reference segment are actually *supported*.
+    # Support is counted in informative sites, so a long interpolated stretch
+    # resting on one discordant site does not qualify while a short stretch
+    # between two adjacent discordant sites does.
+    minimum_sites = max(1, int(min_adjacent_sites))
+    supported_mask = np.zeros_like(mismatch_mask)
+    if covered_positions.size and np.any(mismatch_mask):
+        span_offset = int(covered_positions[0])
+        site_positions = np.flatnonzero((call_row == 1) | (call_row == 2))
+        site_positions = site_positions[
+            (site_positions >= span_offset) & (site_positions <= int(covered_positions[-1]))
+        ]
+        other_sites = site_positions[call_row[site_positions] == other_value] - span_offset
+        # Keep or drop each contiguous stretch *whole*. Trimming a stretch to
+        # its supporting sites would silently re-type it -- a segment running
+        # to the end of the span would stop looking like a right-edge segment
+        # -- so support decides membership only, never geometry.
+        stretch_starts = np.flatnonzero(mismatch_mask & ~np.r_[False, mismatch_mask[:-1]])
+        stretch_ends = np.flatnonzero(mismatch_mask & ~np.r_[mismatch_mask[1:], False])
+        for low, high in zip(stretch_starts, stretch_ends):
+            # Sites inside one stretch are consecutive informative sites all
+            # calling the other reference, so this count is the run length.
+            support = int(np.sum((other_sites >= low) & (other_sites <= high)))
+            if support >= minimum_sites:
+                supported_mask[low : high + 1] = True
+
     mismatch_type = "no_segment_mismatch"
-    if np.any(mismatch_mask):
-        starts = np.flatnonzero(mismatch_mask & ~np.r_[False, mismatch_mask[:-1]])
-        ends = np.flatnonzero(mismatch_mask & ~np.r_[mismatch_mask[1:], False])
+    if np.any(supported_mask):
+        starts = np.flatnonzero(supported_mask & ~np.r_[False, supported_mask[:-1]])
+        ends = np.flatnonzero(supported_mask & ~np.r_[supported_mask[1:], False])
         if len(starts) >= 2:
             mismatch_type = "multi_segment_mismatch"
         elif int(starts[0]) == 0:
@@ -362,7 +452,7 @@ def segment_variant_calls(
         breakpoints=tuple(breakpoints),
         breakpoint_count=len(breakpoints),
         has_breakpoint=bool(breakpoints),
-        has_other_reference_segment=bool(np.any(mismatch_mask)),
+        has_other_reference_segment=bool(np.any(supported_mask)),
         other_reference_segment_type=mismatch_type,
         self_base_count=self_count,
         other_base_count=other_count,

--- a/tests/unit/test_variant_chimera_min_adjacent_sites.py
+++ b/tests/unit/test_variant_chimera_min_adjacent_sites.py
@@ -1,0 +1,154 @@
+"""Reference-switching needs adjacent supporting sites (`F14`).
+
+`segment_variant_calls` and `segment_sparse_variant_calls` interpolate a segment
+class between consecutive informative sites, so a single discordant site opens a
+segment of the other reference spanning every position up to the next site. With
+no minimum support, that made `chimeric_variant_sites` useless: on the `241213`
+pilot it flagged 100% of QC-passing reads (3,860 / 3,861) on the strength of 2-3
+discordant bases out of ~2,300 self-matching ones.
+
+`variant_chimera_min_adjacent_sites` requires a run of N consecutive informative
+sites calling the other reference. Sites, not bases -- variant sites are sparse,
+so a base-length floor would be a proxy for the wrong thing.
+
+Note the deaminase chimera path has carried an equivalent floor
+(`deaminase_chimera_min_events_per_span = 3`) all along; this closes the gap for
+the variant caller.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from smftools.preprocessing.variant_evidence import (
+    SparseVariantCall,
+    segment_sparse_variant_calls,
+    segment_variant_calls,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _sparse(classes, min_adjacent_sites, *, aligned_member_index=0):
+    calls = [
+        SparseVariantCall(position=index * 10, site_id=str(index), observed_base="A", call=call)
+        for index, call in enumerate(classes)
+    ]
+    return segment_sparse_variant_calls(
+        calls,
+        span_start=0,
+        span_end=len(classes) * 10,
+        aligned_member_index=aligned_member_index,
+        min_adjacent_sites=min_adjacent_sites,
+    )
+
+
+def _dense(classes, min_adjacent_sites, *, aligned_member_index=0):
+    """Lay the same site classes out on a sparse genomic grid."""
+    width = len(classes) * 10
+    calls = np.zeros(width, dtype=int)
+    for index, call in enumerate(classes):
+        calls[index * 10] = call
+    covered = np.ones(width, dtype=bool)
+    return segment_variant_calls(
+        calls,
+        covered,
+        aligned_member_index=aligned_member_index,
+        min_adjacent_sites=min_adjacent_sites,
+    )
+
+
+# Two isolated discordant sites separated by concordant ones -- the shape that
+# produced the pilot's 3,786 `multi_segment_mismatch` reads.
+NOISE = [1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 1]
+# A genuine switch: four adjacent sites agreeing on the other reference.
+REAL = [1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1]
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_isolated_sites_are_not_chimeric_at_two(segmenter):
+    """The defect, at the threshold the user asked for."""
+    result = segmenter(NOISE, 2)
+    assert result.has_other_reference_segment is False
+    assert result.other_reference_segment_type == "no_segment_mismatch"
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_adjacent_run_is_still_chimeric(segmenter):
+    """The guard against over-correcting into "nothing is ever chimeric"."""
+    result = segmenter(REAL, 2)
+    assert result.has_other_reference_segment is True
+    assert result.other_reference_segment_type != "no_segment_mismatch"
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_default_of_one_preserves_previous_behavior(segmenter):
+    """Isolated sites still flag at the historical setting.
+
+    Pinned so the change is opt-in at the library boundary and the old
+    behavior stays reachable for comparison against existing generations.
+    """
+    result = segmenter(NOISE, 1)
+    assert result.has_other_reference_segment is True
+    assert result.other_reference_segment_type == "multi_segment_mismatch"
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_exactly_two_adjacent_sites_qualify(segmenter):
+    """The boundary is inclusive: two adjacent sites are a span of two."""
+    classes = [1, 1, 2, 2, 1, 1, 1, 1]
+    assert segmenter(classes, 2).has_other_reference_segment is True
+    assert segmenter(classes, 3).has_other_reference_segment is False
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_counts_stay_raw(segmenter):
+    """Only the interpretation is gated; the statistics are not rewritten.
+
+    `variant_other_base_count` is the evidence used to diagnose `F14` in the
+    first place, so suppressing it along with the flag would remove the means
+    of noticing the next such problem.
+    """
+    result = segmenter(NOISE, 2)
+    assert result.has_other_reference_segment is False
+    assert result.other_base_count > 0
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_threshold_below_one_is_clamped(segmenter):
+    """A nonsensical setting must not disable segmentation entirely."""
+    assert segmenter(REAL, 0).has_other_reference_segment is True
+
+
+@pytest.mark.parametrize("segmenter", [_sparse, _dense], ids=["sparse", "dense"])
+def test_no_informative_sites_is_not_chimeric(segmenter):
+    assert segmenter([1, 1, 1, 1], 2).has_other_reference_segment is False
+
+
+def test_second_member_reads_are_symmetric():
+    """A read aligned to member 2 must be judged against member 1, not member 2."""
+    flipped = [2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2]
+    assert _sparse(flipped, 2, aligned_member_index=1).has_other_reference_segment is False
+    real_flipped = [2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 2, 2]
+    assert _sparse(real_flipped, 2, aligned_member_index=1).has_other_reference_segment is True
+
+
+def test_config_default_is_two():
+    """The pipeline default is the floor, not the historical no-op."""
+    from smftools.config.experiment_config import ExperimentConfig
+
+    assert ExperimentConfig().variant_chimera_min_adjacent_sites == 2
+
+
+def test_config_reads_the_override(tmp_path):
+    """The knob is user-specified from the experiment config sheet."""
+    from smftools.config.experiment_config import ExperimentConfig
+
+    path = tmp_path / "experiment_config.csv"
+    path.write_text(
+        "variable,value,help,options,type\nvariant_chimera_min_adjacent_sites,4,,,int\n",
+        encoding="utf-8",
+    )
+    cfg, _report = ExperimentConfig.from_csv(path)
+    assert cfg.variant_chimera_min_adjacent_sites == 4


### PR DESCRIPTION
Every read that survives modification QC on the `241213` pilot is flagged a reference-switching chimera -- 3,860 of 3,861. Nothing honouring `omit_chimeric_reads` can see any data at all, which is the real reason the HMM clustermaps are empty.

The variant segmenters interpolate a segment class between consecutive informative sites, so one discordant site opens a segment of the other reference running all the way to the next site. There was no minimum support, so that one site was enough. Measured on the pilot's QC-passing reads: ~2,300 bases matching their own reference against 2 or 3 matching the other -- 0.13%, indistinguishable from basecall error at this depth -- and 3,786 of them typed `multi_segment_mismatch` on exactly that basis.

The distribution says where the floor belongs. Per read, the longest run of adjacent informative sites calling the other reference:

    0 sites   5,955 reads
    1 site   10,355 reads   <- noise
    2 sites     499 reads   <- cliff
    3 sites     424 reads
    4+ sites    459 reads

A hard edge between 1 and 2. Requiring two adjacent sites takes the QC-passing chimera rate from 100.0% to 3.6%, which is the shape the pre-partition `variant` CLI's segment clustermaps show: mostly `no_segment_mismatch`, a real minority with genuine multi-hundred-base switches.

Add `variant_chimera_min_adjacent_sites` (default 2), settable from the experiment config sheet, and thread it through both segmenters -- `segment_sparse_variant_calls` for the partitioned pipeline, which is what produced the pilot, and `segment_variant_calls` for the legacy CLI path. Support is counted in *sites*, not bases: variant sites are sparse, so a base-length floor would measure interpolation distance rather than evidence.

The deaminase chimera path has carried an equivalent guard all along (`deaminase_chimera_min_events_per_span = 3`). This closes the same gap for the variant caller, and these are different things: `chimeric_variant_sites` is `has_other_reference_segment`, a read carrying a segment of the *other reference*, not a deaminase PCR chimera.

Two deliberate limits on the blast radius. Support gates membership only, never geometry: a qualifying stretch is kept whole, because trimming it to its supporting sites silently re-types a run-to-the-end segment from `right_segment_mismatch` to `middle_segment_mismatch` -- which is exactly what the first version of this did, caught by the existing reference-contract test. And the counts stay raw: `variant_other_base_count` is the evidence that diagnosed this, so suppressing it alongside the flag would remove the means of noticing the next such problem.

The library defaults stay at 1, so `segment_variant_calls` and `segment_sparse_variant_calls` are unchanged for direct callers and the old behavior remains reachable for comparison against existing generations. Only the config default is 2, so the change applies to pipeline runs.

17 focused tests across both segmenters, including the exactly-two boundary, the guard that a genuine run is still called chimeric, symmetry for reads aligned to the second member, and that the counts survive the gate.

Full suites: 2175 unit, 106 smoke, 55 integration; Ruff check and format clean.

Not done here: no generation is rewritten. Existing published results keep the old flag, and the pilot needs re-running before its chimera numbers mean anything.