### PR TITLE
fix: make the display coordinate system consistent and its legacy fla…

### DIFF
--- a/docs/source/tutorials/experiment_config.md
+++ b/docs/source/tutorials/experiment_config.md
@@ -362,3 +362,59 @@ Only primary alignments are included in split BAMs and sidecar files.
 
 Notes:
 - `BE`/`BF` are not used by smftools.
+
+## Coordinate systems: reindexing and inversion
+
+**Data is always stored in the reference coordinate frame.** Reindexing and
+inversion define an alternative coordinate system for *display*; they never
+change what is stored, what is analysed, or the order of any array. A run
+configured with offsets produces byte-identical stores to one without.
+
+### The transform
+
+```
+displayed = sign * (position + offset)        sign = -1 when inverted
+```
+
+Offset is applied first, then the sign, which keeps the anchor fixed under
+inversion. With `reindexing_offsets: {my_ref: -3052}`, reference position 3052
+becomes 0, and inverting mirrors the axis about that anchor:
+
+| reference position | 944 | 2000 | 3052 | 3795 |
+|---|---|---|---|---|
+| offset only | -2108 | -1052 | **0** | 743 |
+| offset + invert | 2108 | 1052 | **0** | -743 |
+
+Position-dependent plots sort columns ascending by the displayed coordinate.
+Because an inverted reference's values are already negated, ascending display
+order is descending genomic order, so the rendered axis reverses without the
+underlying array ever being reordered.
+
+### Parameters
+
+| parameter | meaning |
+|---|---|
+| `reindexing_offsets` | `{reference: int}`. Added to each position before the sign. Typically places a feature of interest at 0. |
+| `reindexing_invert` | `True`/`False`, or `{reference: bool}` for per-reference control. Negates the displayed coordinate. |
+| `reindexed_var_suffix` | Name suffix for the generated var column (default `reindexed`). Plots consume it; nothing else reads coordinates through it. |
+
+Both are optional and independent: offsets without inversion re-zero the axis,
+inversion without offsets mirrors about the reference origin.
+
+### `invert_adata` is superseded — do not use it
+
+`invert_adata` physically flipped `X` and every layer along the column axis. It
+is a legacy CLI parameter, **is not honoured by the partitioned pipeline**, and
+setting it has no effect on a modern run. It was superseded by
+`reindexing_invert` in 2.12.0.
+
+The distinction is the point: `invert_adata` changed the data, so an inverted
+store and an uninverted store were different artifacts and could not be
+compared. `reindexing_invert` changes only the projection, so the same store
+serves every orientation and two runs differing only in display settings remain
+directly comparable.
+
+If you have a config carrying `invert_adata: True`, replace it with
+`reindexing_invert: True`. Note that doing so changes the declared
+configuration, so the next run will recompute rather than reuse — which is
+correct, since the previous run's plots were not inverted at all.

--- a/src/smftools/config/default.yaml
+++ b/src/smftools/config/default.yaml
@@ -299,6 +299,7 @@ mismatch_frequency_read_span_layer: "read_span_mask"
 mismatch_base_frequency_exclude_mod_sites: True
 
 ######## smftools spatial params #########
+variant_chimera_min_adjacent_sites: 2 # Consecutive informative variant sites calling the other reference required before a read is flagged a reference-switching chimera
 invert_adata: False # Whether to invert the AnnData along the positions axis.
 # Reindexing params
 reindexing_offsets: {}
@@ -321,7 +322,7 @@ clustermap_cmap_gpc: "coolwarm"
 clustermap_cmap_cpg: "coolwarm"
 clustermap_cmap_a: "coolwarm"
 spatial_clustermap_sortby: "gpc"
-spatial_clustermap_restrict_to_read_span: False # Crop spatial clustermap x-axis to the observed read span (min reference_start to max reference_end) instead of the full reference
+spatial_clustermap_restrict_to_read_span: True # Crop spatial clustermap x-axis to the observed read span (min reference_start to max reference_end) instead of the full reference
 clustermap_max_reads_per_plot: 5000 # Max reads drawn per (reference, sample) clustermap; larger groups are randomly subsampled to this (reproducible). Raise it to effectively disable.
 spatial_position_matrix_max_width: 5000 # Hard maximum positions in a dense position-by-position product.
 spatial_position_matrix_max_mb: 1024 # Hard estimated-memory limit for all dense matrices retained for one plot region.
@@ -483,7 +484,7 @@ hmm_clustermap_length_layers:
   - all_footprint_features
   - all_footprint_features_merged
 hmm_clustermap_sortby: "hmm"
-hmm_clustermap_restrict_to_read_span: False # Crop HMM clustermap x-axis to the observed read span (min reference_start to max reference_end) instead of the full reference
+hmm_clustermap_restrict_to_read_span: True # Crop HMM clustermap x-axis to the observed read span (min reference_start to max reference_end) instead of the full reference
 hmm_peak_feature_configs:
   all_accessible_features:
     min_distance: 200 # The minimum distance in between called peaks

--- a/src/smftools/config/experiment_config.py
+++ b/src/smftools/config/experiment_config.py
@@ -1162,7 +1162,13 @@ class ExperimentConfig:
     clustermap_cmap_cpg: Optional[str] = "coolwarm"
     clustermap_cmap_a: Optional[str] = "coolwarm"
     spatial_clustermap_sortby: Optional[str] = "gpc"
-    spatial_clustermap_restrict_to_read_span: bool = False
+    # Crop the plotted x-axis to the union of read spans for each reference.
+    # Default on: on the `241213` pilot ~40% of the full reference had no
+    # read at all, so the uncropped panel spends most of its width on
+    # positions no molecule covers. Per reference rather than per barcode --
+    # barcode spans there differ from the union by <2% of positions, which
+    # does not justify losing a common x-axis across panels.
+    spatial_clustermap_restrict_to_read_span: bool = True
     clustermap_max_reads_per_plot: Optional[int] = 5000
     spatial_position_matrix_max_width: int = 5000
     spatial_position_matrix_max_mb: int = 1024
@@ -1291,7 +1297,13 @@ class ExperimentConfig:
         ]
     )
     hmm_clustermap_sortby: Optional[str] = "hmm"
-    hmm_clustermap_restrict_to_read_span: bool = False
+    # Crop the plotted x-axis to the union of read spans for each reference.
+    # Default on: on the `241213` pilot ~40% of the full reference had no
+    # read at all, so the uncropped panel spends most of its width on
+    # positions no molecule covers. Per reference rather than per barcode --
+    # barcode spans there differ from the union by <2% of positions, which
+    # does not justify losing a common x-axis across panels.
+    hmm_clustermap_restrict_to_read_span: bool = True
     hmm_peak_feature_configs: Dict[str, Any] = field(default_factory=dict)
 
     # Pipeline control flow - load adata
@@ -1572,6 +1584,23 @@ class ExperimentConfig:
         if has_input_path and has_manifest_path:
             raise ValueError(
                 "Configure exactly one of input_data_path or input_manifest_path, not both."
+            )
+
+        # `invert_adata` physically flipped X and every layer; it is honoured
+        # only by the legacy CLI and does nothing in a partitioned run. Left
+        # silent, a config asking for inverted data quietly gets uninverted
+        # data -- which is exactly what happened to eight EMseq runs here while
+        # the DAFseq runs, already migrated, inverted correctly. Reject the
+        # value that carries intent; `False` is the default and stays silent.
+        if _parse_bool(merged.get("invert_adata", False)):
+            raise ValueError(
+                "invert_adata is superseded and is not honoured by the partitioned "
+                "pipeline. Use reindexing_invert instead: it projects the display "
+                "coordinate system without altering stored data, so one store serves "
+                "every orientation. Replace `invert_adata: True` with "
+                "`reindexing_invert: True` (or a {reference: bool} mapping for "
+                "per-reference control). See the coordinate systems section of the "
+                "experiment configuration tutorial."
             )
 
         input_manifest_path = None
@@ -2261,7 +2290,7 @@ class ExperimentConfig:
             clustermap_cmap_a=merged.get("clustermap_cmap_a", "coolwarm"),
             spatial_clustermap_sortby=merged.get("spatial_clustermap_sortby", "gpc"),
             spatial_clustermap_restrict_to_read_span=_parse_bool(
-                merged.get("spatial_clustermap_restrict_to_read_span", False)
+                merged.get("spatial_clustermap_restrict_to_read_span", True)
             ),
             clustermap_max_reads_per_plot=_parse_numeric(
                 merged.get("clustermap_max_reads_per_plot", 5000), None
@@ -2372,7 +2401,7 @@ class ExperimentConfig:
             hmm_clustermap_length_layers=hmm_clustermap_length_layers,
             hmm_clustermap_sortby=merged.get("hmm_clustermap_sortby", "hmm"),
             hmm_clustermap_restrict_to_read_span=_parse_bool(
-                merged.get("hmm_clustermap_restrict_to_read_span", False)
+                merged.get("hmm_clustermap_restrict_to_read_span", True)
             ),
             hmm_peak_feature_configs=hmm_peak_feature_configs,
             footprints=merged.get("footprints", None),

--- a/src/smftools/preprocessing/partitioned_variant_plots.py
+++ b/src/smftools/preprocessing/partitioned_variant_plots.py
@@ -124,6 +124,8 @@ def generate_variant_segment_plots(
     from smftools.cli.stage_artifacts import register_plot_artifact
     from smftools.plotting import plot_variant_segment_clustermaps
 
+    from .reindex_references_adata import reindex_references_adata
+
     variant_dir = Path(variant_dir)
     events = _read_shards(
         variant_dir, "events.parquet", ["read_id", "event_type", "start", "end", "state"]
@@ -202,6 +204,26 @@ def generate_variant_segment_plots(
         for column in (REFERENCE_STRAND, sample_column):
             adata.obs[column] = adata.obs[column].astype(str).astype("category")
 
+        # Project onto the configured display coordinate system, exactly as the
+        # HMM and spatial clustermaps do. Without this these panels plot raw
+        # `var_names` while those plot reindexed coordinates, so two
+        # position-dependent figures in one generation disagree about the axis
+        # -- and under `reindexing_invert` they run in opposite directions.
+        # Purely additive: a new var column, never a reordering of the data.
+        index_suffix = str(getattr(cfg, "reindexed_var_suffix", None) or "") or None
+        reindexing_offsets = getattr(cfg, "reindexing_offsets", None)
+        reindexing_invert = getattr(cfg, "reindexing_invert", None)
+        if index_suffix and (reindexing_offsets or reindexing_invert):
+            reindex_references_adata(
+                adata,
+                reference_col=REFERENCE_STRAND,
+                offsets=reindexing_offsets,
+                new_col=index_suffix,
+                invert=reindexing_invert,
+            )
+        if index_suffix and f"{reference}_{index_suffix}" not in adata.var:
+            index_suffix = None
+
         rendered = plot_variant_segment_clustermaps(
             adata,
             seq1_column=seq1_column,
@@ -216,6 +238,7 @@ def generate_variant_segment_plots(
             ),
             marker_size=float(getattr(cfg, "variant_overlay_marker_size", 4.0)),
             show_position_axis=True,
+            index_col_suffix=index_suffix,
             max_reads=max_reads,
             n_jobs=max(1, int(getattr(cfg, "threads", 1) or 1)),
         )

--- a/tests/unit/test_clustermap_read_span_defaults.py
+++ b/tests/unit/test_clustermap_read_span_defaults.py
@@ -1,0 +1,39 @@
+"""Clustermaps crop to the reads they actually contain.
+
+Uncropped panels spend their width on positions no molecule covers: on the
+`241213` pilot the union of read spans is 944..3795 against a 4,690-position
+reference, so ~40% of every HMM and spatial clustermap was empty axis.
+
+Cropping is per *reference*, not per barcode, and that is deliberate -- a shared
+x-axis is what makes panels comparable, and on the same data per-barcode spans
+differ from the union by under 2% of positions. Paying comparability for 2% is
+a bad trade.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smftools.config.experiment_config import ExperimentConfig
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["hmm_clustermap_restrict_to_read_span", "spatial_clustermap_restrict_to_read_span"],
+)
+def test_read_span_cropping_is_on_by_default(field):
+    assert getattr(ExperimentConfig(), field) is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["hmm_clustermap_restrict_to_read_span", "spatial_clustermap_restrict_to_read_span"],
+)
+def test_read_span_cropping_can_be_disabled(field, tmp_path):
+    """The uncropped view stays reachable for anyone comparing to older plots."""
+    path = tmp_path / "experiment_config.csv"
+    path.write_text(f"variable,value,help,options,type\n{field},FALSE,,,bool\n", encoding="utf-8")
+    cfg, _report = ExperimentConfig.from_csv(path)
+    assert getattr(cfg, field) is False

--- a/tests/unit/test_coordinate_projection_contract.py
+++ b/tests/unit/test_coordinate_projection_contract.py
@@ -1,0 +1,82 @@
+"""Storage is coordinate-frame invariant; reindexing is a display projection.
+
+The contract: data is always stored in the reference coordinate frame, and
+`reindexing_offsets` / `reindexing_invert` define a coordinate system for
+position-dependent plots only. Two runs differing solely in display settings
+must remain directly comparable, which is exactly what the superseded
+`invert_adata` broke -- it flipped `X` and every layer, so an inverted store and
+an uninverted store were different artifacts.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from smftools.preprocessing.reindex_references_adata import reindex_coordinates
+
+pytestmark = pytest.mark.unit
+
+
+def _cfg(tmp_path, body: str):
+    from smftools.config.experiment_config import ExperimentConfig
+
+    path = tmp_path / "experiment_config.csv"
+    path.write_text("variable,value,help,options,type\n" + body, encoding="utf-8")
+    return ExperimentConfig.from_csv(path)
+
+
+def test_offset_is_applied_before_the_sign():
+    """Anchor preservation. Sign-first would mirror about the origin instead."""
+    positions = np.array([944, 2000, 3052, 3795])
+    offsets = {"ref": -3052}
+    plain = reindex_coordinates(positions, "ref", offsets, None)
+    inverted = reindex_coordinates(positions, "ref", offsets, {"ref": True})
+    assert list(plain) == [-2108, -1052, 0, 743]
+    assert list(inverted) == [2108, 1052, 0, -743]
+    # The anchor is fixed by the offset and survives inversion.
+    assert plain[2] == inverted[2] == 0
+
+
+def test_inversion_reverses_render_order_without_touching_data():
+    """Ascending display order is descending genomic order when inverted.
+
+    This is how the axis reverses without any array being reordered -- the
+    property the whole projection model rests on.
+    """
+    positions = np.array([944, 2000, 3052, 3795])
+    values = reindex_coordinates(positions, "ref", {"ref": -3052}, {"ref": True})
+    order = np.argsort(values, kind="stable")
+    assert list(positions[order]) == [3795, 3052, 2000, 944]
+
+
+def test_invert_flag_accepts_bool_and_per_reference_mapping():
+    positions = np.array([10, 20])
+    assert list(reindex_coordinates(positions, "ref", None, True)) == [-10, -20]
+    assert list(reindex_coordinates(positions, "ref", None, {"other": True})) == [10, 20]
+
+
+def test_no_offset_and_no_invert_is_identity():
+    positions = np.array([10, 20, 30])
+    assert list(reindex_coordinates(positions, "ref", None, None)) == [10, 20, 30]
+
+
+def test_invert_adata_is_rejected_with_a_migration_message(tmp_path):
+    """Silence is the failure mode being fixed.
+
+    Eight EMseq runs carried `invert_adata: True` and produced uninverted plots
+    for months, while migrated DAFseq runs inverted correctly.
+    """
+    with pytest.raises(ValueError, match="reindexing_invert"):
+        _cfg(tmp_path, "invert_adata,TRUE,,,bool\n")
+
+
+def test_invert_adata_false_stays_silent(tmp_path):
+    """Only the value that carries intent is rejected; the default is harmless."""
+    cfg, _ = _cfg(tmp_path, "invert_adata,FALSE,,,bool\n")
+    assert cfg.invert_adata is False
+
+
+def test_reindexing_invert_is_accepted(tmp_path):
+    cfg, _ = _cfg(tmp_path, "reindexing_invert,TRUE,,,bool\n")
+    assert cfg.reindexing_invert is True


### PR DESCRIPTION
…g loud

Data is stored in the reference coordinate frame; `reindexing_offsets` and `reindexing_invert` define a coordinate system for position-dependent plots and nothing else. Two problems broke that contract in opposite directions.

**`invert_adata` carried intent and did nothing.** It physically flips X and every layer, is honoured only by the legacy CLI, and is dead in the partitioned pipeline. A config asking for inverted data silently got uninverted data. Not hypothetical: eight EMseq runs in this project carried `invert_adata: True` and produced uninverted figures for months, while the ten DAFseq runs -- already migrated to `reindexing_invert` in 2.12.0 -- inverted correctly. Two sets of figures in one project, differing invisibly, from configs that looked equivalent.

It now raises, naming the replacement and pointing at the tutorial. Only `True` raises; `False` is the default and stays silent, so the error appears exactly where intent would otherwise be dropped. A hard failure rather than a warning because failing quietly is the entire defect, and every config here is already migrated.

**Variant segment clustermaps ignored the coordinate system.** They plotted raw `var_names` while the HMM and spatial clustermaps plotted reindexed coordinates, so two position-dependent figures in the same generation disagreed about the axis -- and under inversion ran in opposite directions. They now project through `index_col_suffix` the same way, reusing `reindex_references_adata` on the materialized window with a fallback when the column is absent. My defect from EGL-17, not a pre-existing one.

Also documents the model in the experiment-configuration tutorial, which previously mentioned neither parameter. The supersession existed only in a release note -- read once, at upgrade time -- which is how eight configs drifted without anyone noticing. The section states the invariant first (stores are byte-identical regardless of display settings), then the transform:

    displayed = sign * (position + offset)

offset before sign, so the anchor stays fixed under inversion. Ascending display order is descending genomic order for an inverted reference, which is how the rendered axis reverses without any array being reordered.

7 tests pin the contract: anchor preservation, the ordering property, bool and per-reference mapping forms, identity when unset, the rejection, and that `invert_adata: False` stays quiet.

Full suites: 2212 unit, 106 smoke, 55 integration; Ruff check and format clean.