### PR TITLE
fix: stop dorado's unclassified reads becoming a barcode

### DIFF
--- a/src/smftools/informatics/bam_functions.py
+++ b/src/smftools/informatics/bam_functions.py
@@ -3936,6 +3936,33 @@ def build_classified_read_set(
     return classified_reads, read_to_barcode
 
 
+# Dorado writes reads it could not assign to a barcode into a file named after
+# the run id and basecall model (e.g.
+# "ba0e54a1-67ab-4f30-b7e7-15db5782e51f_dna_r10.4.1_e8.2_400bps_sup@v5.2.0.bam"),
+# not "unclassified.bam". Callers that filter on the word "unclassified" miss
+# it, and a filename-derived barcode then turns that run id into a sample: on
+# the `241213` pilot it became the largest "barcode" in the experiment, 85,436
+# of 268,489 sidecar reads.
+_DORADO_RUN_ID_PREFIX = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(_|$)",
+    flags=re.IGNORECASE,
+)
+
+
+def is_unclassified_bam_name(name: str) -> bool:
+    """Whether a demux output filename holds unbarcoded reads.
+
+    Recognises both spellings dorado uses: an explicit "unclassified" in the
+    name, and the run-id-prefixed name it emits instead. Matching on the run-id
+    shape rather than on any particular model string keeps this working when the
+    basecall model changes.
+    """
+    stem = str(name).strip()
+    if "unclassified" in stem.lower():
+        return True
+    return bool(_DORADO_RUN_ID_PREFIX.match(stem))
+
+
 def build_barcode_sidecar_from_split_bams(
     bam_files: list[Path],
     output_path: Path,
@@ -3972,6 +3999,15 @@ def build_barcode_sidecar_from_split_bams(
         # Infer barcode label from filename (e.g. "barcode01.bam" -> "01")
         stem = bam_path.stem
         match = re.search(r"barcode([0-9A-Za-z\-]+)", stem, flags=re.IGNORECASE)
+        if match is None and is_unclassified_bam_name(stem):
+            # Unbarcoded reads. Falling back to the stem here is what invented a
+            # run id as a barcode; skip the file rather than name a sample after
+            # it. Reads carrying a real BC tag are still picked up from the
+            # per-barcode files.
+            logger.info(
+                "Skipping unclassified demux output %s (%s)", bam_path.name, "no barcode in name"
+            )
+            continue
         filename_barcode = match.group(1) if match else stem
 
         with pysam_mod.AlignmentFile(str(bam_path), "rb", check_sq=False) as bam:
@@ -4038,7 +4074,9 @@ def rebuild_barcode_sidecar_via_dorado_classification(
             no_classify=False,
             file_prefix="",
         )
-        bam_files_for_sidecar = [p for p in classified_bam_files if "unclassified" not in p.name]
+        bam_files_for_sidecar = [
+            p for p in classified_bam_files if not is_unclassified_bam_name(p.stem)
+        ]
         build_barcode_sidecar_from_split_bams(
             bam_files_for_sidecar,
             barcode_sidecar,

--- a/tests/unit/test_unclassified_barcode_naming.py
+++ b/tests/unit/test_unclassified_barcode_naming.py
@@ -1,0 +1,60 @@
+"""Unbarcoded reads must not become a sample (`F19`).
+
+Dorado writes reads it could not assign to a barcode into a file named after the
+run id and basecall model -- not "unclassified.bam". Two places assumed the
+literal word: the caller filtering demux outputs, and the sidecar builder, which
+fell back to the whole filename when its `barcode(\\d+)` pattern did not match.
+
+The result was a run id travelling through the pipeline as a barcode. On the
+`241213` pilot it was the largest "sample" in the experiment -- 85,436 of
+268,489 sidecar reads, and 4,646 of 19,328 analysed reads -- appearing in every
+per-sample plot and statistic as if it were a real library member.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smftools.informatics.bam_functions import is_unclassified_bam_name
+
+pytestmark = pytest.mark.unit
+
+RUN_ID_NAME = "ba0e54a1-67ab-4f30-b7e7-15db5782e51f_dna_r10.4.1_e8.2_400bps_sup@v5.2.0"
+
+
+def test_run_id_prefixed_output_is_unclassified():
+    """The exact name that produced the phantom sample."""
+    assert is_unclassified_bam_name(RUN_ID_NAME) is True
+
+
+def test_literal_unclassified_is_still_recognised():
+    """The spelling the original filter looked for must keep working."""
+    assert is_unclassified_bam_name("unclassified") is True
+    assert is_unclassified_bam_name("some_prefix_unclassified") is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["SQK-NBD114-24_barcode08", "barcode01", "BARCODE12", "SQK-RBK114-96_barcode24"],
+)
+def test_real_barcode_files_are_kept(name):
+    assert is_unclassified_bam_name(name) is False
+
+
+def test_custom_pool_names_are_kept():
+    """Guard against over-correcting.
+
+    The stem fallback exists for kits whose files are not named `barcodeNN`.
+    Only the run-id shape is treated as unclassified, so those still work.
+    """
+    assert is_unclassified_bam_name("my_custom_pool") is False
+    assert is_unclassified_bam_name("sampleA") is False
+
+
+def test_matching_is_anchored_not_substring():
+    """A uuid *inside* a name is not the dorado unclassified pattern."""
+    assert is_unclassified_bam_name(f"barcode01_{RUN_ID_NAME}") is False
+
+
+def test_bare_run_id_without_model_suffix():
+    assert is_unclassified_bam_name("ba0e54a1-67ab-4f30-b7e7-15db5782e51f") is True


### PR DESCRIPTION
The largest "sample" in the `241213` experiment was not a sample. It was `ba0e54a1-67ab-4f30-b7e7-15db5782e51f_dna_r10.4.1_e8.2_400bps_sup@v5.2.0` -- a run id and basecall model -- carrying 85,436 of 268,489 sidecar reads (32%) and 4,646 of 19,328 analysed reads (24%), and appearing in every per-sample plot and statistic as if it were a library member.

Dorado writes reads it cannot assign to a barcode into a file named after the run id and model, not `unclassified.bam`. Two places assumed the literal word:

- `rebuild_barcode_sidecar_via_dorado_classification` filtered demux outputs with `"unclassified" not in p.name`, which does not match that name;
- `build_barcode_sidecar_from_split_bams` then fell back to `filename_barcode = stem` when its `barcode(\d+)` pattern did not match, which turned the run id into a barcode label.

Either alone would have been harmless. Together the reads passed the filter and were then named after the file that held them.

Add `is_unclassified_bam_name` and use it at both sites. It matches the run-id *shape* -- an anchored UUID -- rather than any particular model string, so it keeps working when the basecall model changes, which a match on `dna_r10.4.1_...` would not.

The stem fallback is deliberately kept for everything else. It exists for kits whose per-barcode files are not named `barcodeNN`, and removing it would break those; only the run-id shape is now treated as unclassified. A uuid appearing *inside* a name (`barcode01_<uuid>`) is not matched, since the pattern is anchored.

Scope: this is a raw-stage intermediate, so clearing an affected experiment needs a fresh raw generation rather than a preprocess redo. Totals in existing outputs are unaffected -- the reads were real -- but any per-sample breakdown computed over them includes a group that should not exist. The `251105` DAFseq run has no such group, so this depends on how a given run was demuxed rather than on the kit.

9 focused tests: the exact name that caused this, the literal `unclassified` spelling that must keep working, real barcode files across two kits, custom pool names (the over-correction guard), anchoring, and a bare run id with no model suffix.

Full unit suite 2,221 passed; Ruff check and format clean.